### PR TITLE
Initialize task form time to undefined

### DIFF
--- a/blotztask-ui/src/app/dashboard/navbar/components/global-add-task-form.tsx
+++ b/blotztask-ui/src/app/dashboard/navbar/components/global-add-task-form.tsx
@@ -20,7 +20,7 @@ const GlobalAddTaskForm = ({ handleSubmit }) => {
       description: '',
       date: new Date(),
       labelId: undefined,
-      time: '',
+      time: undefined,
     },
   });
 


### PR DESCRIPTION
An undefined time is valid for an optional value, so we initialize this to undefined.