### PR TITLE
Migrate task-completion-status endpoint to CQRS

### DIFF
--- a/blotztask-api/Modules/Tasks/Commands/Tasks/TaskStatusUpdate.cs
+++ b/blotztask-api/Modules/Tasks/Commands/Tasks/TaskStatusUpdate.cs
@@ -4,28 +4,28 @@ using System.ComponentModel.DataAnnotations;
 
 namespace BlotzTask.Modules.Tasks.Commands.Tasks;
 
-public class TaskStatusUpdateQuery
+public class TaskStatusUpdateCommand
 {
     [Required]
     public int TaskId { get; set; }
     public bool? IsDone { get; set; }
 }
 
-public class TaskStatusUpdateQueryHandler(BlotzTaskDbContext db, ILogger<TaskStatusUpdateQueryHandler> logger)
+public class TaskStatusUpdateCommandHandler(BlotzTaskDbContext db, ILogger<TaskStatusUpdateCommandHandler> logger)
 {
-    public async Task<TaskStatusResultDto> Handle(TaskStatusUpdateQuery query, CancellationToken ct = default)
+    public async Task<TaskStatusResultDto> Handle(TaskStatusUpdateCommand command, CancellationToken ct = default)
     {
-        logger.LogInformation("Finding task {Id}", query.TaskId);
+        logger.LogInformation("Finding task {Id}", command.TaskId);
 
-        var task = await db.TaskItems.FindAsync(query.TaskId, ct);
+        var task = await db.TaskItems.FindAsync(command.TaskId, ct);
 
         if (task == null)
         {
-            throw new NotFoundException($"Task with ID {query.TaskId} was not found.");
+            throw new NotFoundException($"Task with ID {command.TaskId} was not found.");
         }
 
         // If task.IsDone is null, set it to be false, otherwise, toggle the task.IsDone
-        task.IsDone = query.IsDone ?? !task.IsDone;
+        task.IsDone = command.IsDone ?? !task.IsDone;
 
         logger.LogInformation("The completion status of task {Id} was changed to {IsDone}", task.Id, task.IsDone);
 

--- a/blotztask-api/Modules/Tasks/Commands/Tasks/TaskStatusUpdate.cs
+++ b/blotztask-api/Modules/Tasks/Commands/Tasks/TaskStatusUpdate.cs
@@ -1,0 +1,50 @@
+﻿using BlotzTask.Infrastructure.Data;
+using BlotzTask.Shared.Exceptions;
+using System.ComponentModel.DataAnnotations;
+
+namespace BlotzTask.Modules.Tasks.Commands.Tasks;
+
+public class TaskStatusUpdateQuery
+{
+    [Required]
+    public int TaskId { get; set; }
+    public bool? IsDone { get; set; }
+}
+
+public class TaskStatusUpdateQueryHandler(BlotzTaskDbContext db, ILogger<TaskStatusUpdateQueryHandler> logger)
+{
+    public async Task<TaskStatusResultDto> Handle(TaskStatusUpdateQuery query, CancellationToken ct = default)
+    {
+        logger.LogInformation("Finding task {Id}", query.TaskId);
+
+        var task = await db.TaskItems.FindAsync(query.TaskId, ct);
+
+        if (task == null)
+        {
+            throw new NotFoundException($"Task with ID {query.TaskId} was not found.");
+        }
+
+        // If task.IsDone is null, set it to be false, otherwise, toggle the task.IsDone
+        task.IsDone = query.IsDone ?? !task.IsDone;
+
+        logger.LogInformation("The completion status of task {Id} was changed to {IsDone}", task.Id, task.IsDone);
+
+        task.UpdatedAt = DateTime.UtcNow;
+        db.TaskItems.Update(task);
+        await db.SaveChangesAsync(ct);
+
+        return new TaskStatusResultDto
+        {
+            Id = task.Id,
+            UpdatedAt = task.UpdatedAt,
+            Message = task.IsDone ? "Task marked as completed." : "Task marked as incomplete."
+        };
+    }
+}
+
+public class TaskStatusResultDto
+{
+    public int Id { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public string Message { get; set; } = string.Empty;
+}

--- a/blotztask-api/Modules/Tasks/Controllers/TaskController.cs
+++ b/blotztask-api/Modules/Tasks/Controllers/TaskController.cs
@@ -13,7 +13,7 @@ namespace BlotzTask.Modules.Tasks.Controllers;
 [ApiController]
 [Route("/api/[controller]")]
 [Authorize]
-public class TaskController(ITaskService taskService, GetTasksByDateQueryHandler  getTasksByDateQueryHandler, TaskStatusUpdateQueryHandler taskStatusUpdateQueryHandler) : ControllerBase
+public class TaskController(ITaskService taskService, GetTasksByDateQueryHandler  getTasksByDateQueryHandler, TaskStatusUpdateCommandHandler taskStatusUpdateCommandHandler) : ControllerBase
 {
     [HttpGet]
     [Obsolete("This endpoint is not in use and will be removed later.")]
@@ -106,12 +106,12 @@ public class TaskController(ITaskService taskService, GetTasksByDateQueryHandler
     [HttpPut("task-completion-status/{id}")]
     public async Task<TaskStatusResultDto> TaskStatusUpdate(int id, CancellationToken ct)
     {
-        var query = new TaskStatusUpdateQuery
+        var command = new TaskStatusUpdateCommand
         {
             TaskId = id,
         };
 
-        var result = await taskStatusUpdateQueryHandler.Handle(query, ct);
+        var result = await taskStatusUpdateCommandHandler.Handle(command, ct);
 
         if (result == null)
         {

--- a/blotztask-api/Modules/Tasks/Controllers/TaskController.cs
+++ b/blotztask-api/Modules/Tasks/Controllers/TaskController.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
 using BlotzTask.Modules.Tasks.DTOs;
 using BlotzTask.Modules.Tasks.Queries.Tasks;
+using BlotzTask.Modules.Tasks.Commands.Tasks;
 using BlotzTask.Modules.Tasks.Services;
 using BlotzTask.Shared.DTOs;
 using Microsoft.AspNetCore.Authorization;
@@ -12,7 +13,7 @@ namespace BlotzTask.Modules.Tasks.Controllers;
 [ApiController]
 [Route("/api/[controller]")]
 [Authorize]
-public class TaskController(ITaskService taskService, GetTasksByDateQueryHandler  getTasksByDateQueryHandler) : ControllerBase
+public class TaskController(ITaskService taskService, GetTasksByDateQueryHandler  getTasksByDateQueryHandler, TaskStatusUpdateQueryHandler taskStatusUpdateQueryHandler) : ControllerBase
 {
     [HttpGet]
     [Obsolete("This endpoint is not in use and will be removed later.")]
@@ -103,19 +104,22 @@ public class TaskController(ITaskService taskService, GetTasksByDateQueryHandler
     }
 
     [HttpPut("task-completion-status/{id}")]
-    public async Task<IActionResult> TaskStatusUpdate(int id)
+    public async Task<TaskStatusResultDto> TaskStatusUpdate(int id, CancellationToken ct)
     {
+        var query = new TaskStatusUpdateQuery
+        {
+            TaskId = id,
+        };
 
-        var taskStatusResultDto = await taskService.TaskStatusUpdate(id);
+        var result = await taskStatusUpdateQueryHandler.Handle(query, ct);
 
-        if (taskStatusResultDto == null)
+        if (result == null)
         {
             throw new InvalidOperationException($"Task status update failed: no valid data returned for task ID {id}.");
         }
-        var message = taskStatusResultDto.Message;
-        return Ok(new ResponseWrapper<int>(id, message, true));
-    }
 
+        return result;
+    }
 
     [HttpDelete("{id}")]
     public async Task<IActionResult> DeleteTaskById(int id)

--- a/blotztask-api/Modules/Tasks/DTOs/TaskStatusResultDTO.cs
+++ b/blotztask-api/Modules/Tasks/DTOs/TaskStatusResultDTO.cs
@@ -1,8 +1,0 @@
-namespace BlotzTask.Modules.Tasks.DTOs;
-
-public class TaskStatusResultDto
-{
-    public int Id { get; set; }
-    public DateTime UpdatedAt { get; set; }
-    public string Message {get; set;} = string.Empty;
-}

--- a/blotztask-api/Modules/Tasks/DependencyInjection.cs
+++ b/blotztask-api/Modules/Tasks/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using BlotzTask.Modules.Tasks.Commands.SubTasks;
+using BlotzTask.Modules.Tasks.Commands.Tasks;
 using BlotzTask.Modules.Tasks.Queries.Tasks;
 
 namespace BlotzTask.Modules.Tasks;
@@ -9,6 +10,7 @@ public static class DependencyInjection
     {
         // Manual registration of command handlers
         services.AddScoped<UpdateSubtaskCommandHandler>();
+        services.AddScoped<TaskStatusUpdateQueryHandler>();
         
         // Manual registration of query handlers 
         services.AddScoped<GetTasksByDateQueryHandler>();

--- a/blotztask-api/Modules/Tasks/DependencyInjection.cs
+++ b/blotztask-api/Modules/Tasks/DependencyInjection.cs
@@ -10,7 +10,7 @@ public static class DependencyInjection
     {
         // Manual registration of command handlers
         services.AddScoped<UpdateSubtaskCommandHandler>();
-        services.AddScoped<TaskStatusUpdateQueryHandler>();
+        services.AddScoped<TaskStatusUpdateCommandHandler>();
         
         // Manual registration of query handlers 
         services.AddScoped<GetTasksByDateQueryHandler>();

--- a/blotztask-api/Modules/Tasks/Services/TaskService.cs
+++ b/blotztask-api/Modules/Tasks/Services/TaskService.cs
@@ -15,7 +15,6 @@ public interface ITaskService
     public Task<ResponseWrapper<int>> EditTaskAsync(int id, EditTaskItemDto editTaskItem);
     public Task<ResponseWrapper<int>> DeleteTaskByIdAsync(int id);
     public Task<ResponseWrapper<string>> AddTaskAsync(AddTaskItemDto addTaskItem, string userId);
-    public Task<TaskStatusResultDto> TaskStatusUpdate(int id, bool? isDone = null);
     public Task<List<TaskItemDto>> GetTodayDoneTasks(string userId);
     public Task<MonthlyStatDto> GetMonthlyStats(string userId, int year, int month);
     public Task<ResponseWrapper<int>> RestoreFromTrashAsync(int id);
@@ -188,30 +187,6 @@ public class TaskService : ITaskService
             Console.Error.WriteLine($"Error editing task: {ex.Message}");
             throw;
         }
-    }
-
-    public async Task<TaskStatusResultDto> TaskStatusUpdate(int taskId, bool? isDone = null)
-    {
-        var task = await _dbContext.TaskItems.FindAsync(taskId);
-
-        if (task == null)
-        {
-            throw new NotFoundException($"Task with ID {taskId} was not found.");
-        }
-
-        // If task.IsDone is null, set it to be false, otherwise, toggle the task.IsDone
-        task.IsDone = isDone ?? !task.IsDone;
-
-        task.UpdatedAt = DateTime.UtcNow;
-        _dbContext.TaskItems.Update(task);
-        await _dbContext.SaveChangesAsync();
-
-        return new TaskStatusResultDto
-        {
-            Id = task.Id,
-            UpdatedAt = task.UpdatedAt,
-            Message = task.IsDone ? "Task marked as completed." : "Task marked as incomplete."
-        };
     }
 
     public async Task<List<TaskItemDto>> GetTodayDoneTasks(string userId)


### PR DESCRIPTION
New endpoint tested on Postman:
<img width="2398" height="1441" alt="屏幕截图 2025-08-28 180952" src="https://github.com/user-attachments/assets/a3cc199d-5801-4496-bcb1-0aec522b03c2" />
<img width="2338" height="1510" alt="屏幕截图 2025-08-28 181314" src="https://github.com/user-attachments/assets/13f03891-8c57-4ad5-a734-c4927741b3e0" />
