### PR TITLE
Filter task status bar by selected date

### DIFF
--- a/blotztask-mobile/src/feature/calendar/components/filtered-task-list.tsx
+++ b/blotztask-mobile/src/feature/calendar/components/filtered-task-list.tsx
@@ -76,6 +76,7 @@ export const FilteredTaskList = ({ selectedDay }: { selectedDay: Date }) => {
         doneTaskCount={findStatusCount("Done")}
         selectedStatus={selectedStatus}
         onChange={setSelectedStatus}
+        selectedDay={selectedDay}
       />
 
       {isLoading ? (

--- a/blotztask-mobile/src/shared/components/ui/task-status-row.tsx
+++ b/blotztask-mobile/src/shared/components/ui/task-status-row.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { View, ScrollView, SafeAreaView } from "react-native";
 import { TaskStatusType } from "../../../feature/calendar/models/task-status-type";
 import { TaskStatusButton } from "@/shared/components/ui/task-status-button";
+import { startOfDay, isBefore, isAfter } from "date-fns";
 
 export function TaskStatusRow({
   allTaskCount,
@@ -11,6 +12,7 @@ export function TaskStatusRow({
   overdueTaskCount,
   selectedStatus,
   onChange,
+  selectedDay,
 }: {
   allTaskCount: number;
   todoTaskCount: number;
@@ -19,7 +21,16 @@ export function TaskStatusRow({
   overdueTaskCount: number;
   selectedStatus: TaskStatusType;
   onChange: (value: TaskStatusType) => void;
+  selectedDay?: Date;
 }) {
+  // Determine if the selected day is past, today, or future
+  const today = startOfDay(new Date());
+  const selectedDate = selectedDay ? startOfDay(selectedDay) : today;
+
+  const isPastDate = isBefore(selectedDate, today);
+  const isFutureDate = isAfter(selectedDate, today);
+  const isToday = !isPastDate && !isFutureDate;
+
   return (
     <SafeAreaView>
       <ScrollView horizontal={true} showsHorizontalScrollIndicator={false} className="mb-4">
@@ -30,30 +41,38 @@ export function TaskStatusRow({
             statusName="All"
             taskCount={allTaskCount}
           />
-          <TaskStatusButton
-            isSelected={selectedStatus === "To Do"}
-            onChange={() => onChange("To Do")}
-            statusName="To Do"
-            taskCount={todoTaskCount}
-          />
-          <TaskStatusButton
-            isSelected={selectedStatus === "In Progress"}
-            onChange={() => onChange("In Progress")}
-            statusName="In Progress"
-            taskCount={inProgressTaskCount}
-          />
-          <TaskStatusButton
-            isSelected={selectedStatus === "Done"}
-            onChange={() => onChange("Done")}
-            statusName="Done"
-            taskCount={doneTaskCount}
-          />
-          <TaskStatusButton
-            isSelected={selectedStatus === "Overdue"}
-            onChange={() => onChange("Overdue")}
-            statusName="Overdue"
-            taskCount={overdueTaskCount}
-          />
+          {(isToday || isFutureDate) && (
+            <TaskStatusButton
+              isSelected={selectedStatus === "To Do"}
+              onChange={() => onChange("To Do")}
+              statusName="To Do"
+              taskCount={todoTaskCount}
+            />
+          )}
+          {(isToday || isFutureDate) && (
+            <TaskStatusButton
+              isSelected={selectedStatus === "In Progress"}
+              onChange={() => onChange("In Progress")}
+              statusName="In Progress"
+              taskCount={inProgressTaskCount}
+            />
+          )}
+          {(isToday || isPastDate) && (
+            <TaskStatusButton
+              isSelected={selectedStatus === "Done"}
+              onChange={() => onChange("Done")}
+              statusName="Done"
+              taskCount={doneTaskCount}
+            />
+          )}
+          {(isToday || isPastDate) && (
+            <TaskStatusButton
+              isSelected={selectedStatus === "Overdue"}
+              onChange={() => onChange("Overdue")}
+              statusName="Overdue"
+              taskCount={overdueTaskCount}
+            />
+          )}
         </View>
       </ScrollView>
     </SafeAreaView>


### PR DESCRIPTION
Ticket: https://github.com/Blotz-Org/Blotz-Task-App-Private/issues/888
Added filtering logic in frontend
Tested on Android emulator:
Past date:
<img width="400" height="800" alt="屏幕截图 2025-10-29 160849" src="https://github.com/user-attachments/assets/984cea33-bd8f-4b17-87e5-0d1e66473160" />
Today:
<img width="400" height="800" alt="屏幕截图 2025-10-29 160841" src="https://github.com/user-attachments/assets/019f5544-c081-4f57-a509-9ea3c48d2108" />
Future date:
<img width="400" height="800" alt="屏幕截图 2025-10-29 160858" src="https://github.com/user-attachments/assets/b4daf8fb-8cc7-40e6-a036-345e8fa93b42" />