### PR TITLE
Bug Fix for Window OS and Android: building

### DIFF
--- a/blotztask-mobile/babel.config.js
+++ b/blotztask-mobile/babel.config.js
@@ -2,6 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: [["babel-preset-expo", { jsxImportSource: "nativewind" }], "nativewind/babel"],
-    plugins: ["react-native-worklets/plugin"],
+    plugins: ["react-native-reanimated/plugin"],
   };
 };


### PR DESCRIPTION
Fix Babel config to remove invalid `react-native-worklets` plugin

updates `babel.config.js` to remove the `react-native-worklets/plugin` entry and align the config with the current Expo setup.

changes fix the Metro bundler error:

> Cannot find module 'react-native-worklets/plugin'

and allow the Android bundle to build successfully again.
