### PR TITLE
refactor: fix settings route path and enable navigation from user details

### DIFF
--- a/blotztask-mobile/src/app/(protected)/(tabs)/settings/index.tsx
+++ b/blotztask-mobile/src/app/(protected)/(tabs)/settings/index.tsx
@@ -19,31 +19,31 @@ export default function SettingsScreen() {
       key: "account",
       label: t("menu.account"),
       icon: "account-outline",
-      route: "/(protected)/settings/account",
+      route: "/settings/account",
     },
     {
       key: "task-handling",
       label: t("menu.taskHandling"),
       icon: "file-check-outline",
-      route: "/(protected)/settings/task-handling",
+      route: "/settings/task-handling",
     },
     {
       key: "notifications",
       label: t("menu.notifications"),
       icon: "bell-outline",
-      route: "/(protected)/settings/notifications",
+      route: "/settings/notifications",
     },
     {
       key: "language",
       label: t("menu.language"),
       icon: "translate",
-      route: "/(protected)/settings/language",
+      route: "/settings/language",
     },
     {
       key: "under-development",
       label: t("menu.allTasks"),
       icon: "cog-outline",
-      route: "/(protected)/settings/all-tasks",
+      route: "/settings/all-tasks",
     },
   ];
 
@@ -52,7 +52,7 @@ export default function SettingsScreen() {
     : PNGIMAGES.blotzIcon;
 
   const handleProfileEdit = () => {
-    router.push("/(protected)/settings/avatar" as const);
+    router.push("/settings/avatar" as const);
   };
 
   return (

--- a/blotztask-mobile/src/app/(protected)/user-details.tsx
+++ b/blotztask-mobile/src/app/(protected)/user-details.tsx
@@ -29,7 +29,7 @@ export default function UserDetailsScreen() {
           <Text className="flex-1 ml-2 mt-2 font-balooBold text-4xl leading-normal">{t("profile.title")}</Text>
         </View>
         <CardIdentityView />
-        <CardEditButton onPress={() => {}} />
+        <CardEditButton onPress={() => router.push("/settings")} />
       </View>
     </SafeAreaView>
   );


### PR DESCRIPTION
- Button Navigate: The edit button will navigate the user to the SettingsScreen in the application.
- Fix route path from `route: "/(protected)/settings/xxx"` to `route: "/settings/xxx",`. Reference: https://docs.expo.dev/router/basics/notation/