### PR TITLE
Calendar UI bug

### DIFF
--- a/blotztask-mobile/src/feature/calendar/screens/calendar-screen.tsx
+++ b/blotztask-mobile/src/feature/calendar/screens/calendar-screen.tsx
@@ -13,12 +13,14 @@ import { CustomDay, CustomDayProps } from "../components/custom-day";
 import { useLocalSearchParams } from "expo-router";
 import { ModeBottomSheet } from "../../pomodoro/components/pomodoro-mode-bottomsheet";
 import { usePomodoroSettingsQuery } from "../../pomodoro/hooks/usePomodoroSetting";
+import { useTranslation } from "react-i18next";
 
 const calendarTheme = {
   calendarBackground: theme.colors.background,
 };
 
 export default function CalendarScreen() {
+  const { i18n } = useTranslation();
   const params = useLocalSearchParams<{ selectedDate?: string | string[] }>();
   const [selectedDay, setSelectedDay] = useState(new Date());
   const [calendarKey, setCalendarKey] = useState(0);
@@ -63,7 +65,7 @@ export default function CalendarScreen() {
         }}
       />
       <CalendarProvider
-        key={calendarKey}
+        key={`${calendarKey}-${i18n.language}`}
         date={format(selectedDay, "yyyy-MM-dd")}
         onDateChanged={(date: string) => {
           setSelectedDay(new Date(date));

--- a/blotztask-mobile/src/feature/monthly-calendar/components/day-detail-panel.tsx
+++ b/blotztask-mobile/src/feature/monthly-calendar/components/day-detail-panel.tsx
@@ -1,5 +1,5 @@
 import { View, Text, ActivityIndicator } from "react-native";
-import { BottomSheetScrollView } from "@gorhom/bottom-sheet"; 
+import { BottomSheetScrollView } from "@gorhom/bottom-sheet";
 import { format, parseISO } from "date-fns";
 import useSelectedDayTasks from "@/shared/hooks/useSelectedDayTasks";
 import { theme } from "@/shared/constants/theme";
@@ -27,7 +27,7 @@ export const SelectedDayDetailPanel = ({ selectedDay }: { selectedDay: Date }) =
               return (
                 <View
                   key={task.id || index}
-                  className="flex-row items-center bg-white border border-gray-100 rounded-2xl mb-2 py-2.5 px-4 shadow-xs"
+                  className="flex-row items-center bg-white border border-gray-100 rounded-2xl mb-2 py-3 px-4 shadow-xs"
                 >
                   {/* Column 1: Time */}
                   <View className="w-16">

--- a/blotztask-mobile/src/feature/monthly-calendar/screens/monthly-calendar-screen.tsx
+++ b/blotztask-mobile/src/feature/monthly-calendar/screens/monthly-calendar-screen.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Pressable, Text, View , Platform} from "react-native";
+import { Pressable, Text, View, Platform } from "react-native";
 import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 import { Calendar, DateData } from "react-native-calendars";
 import { format } from "date-fns";
@@ -26,8 +26,8 @@ export default function MonthlyCalendarScreen() {
   const [selectedDay, setSelectedDay] = useState(new Date(selectedDate || new Date()));
   const { monthlyTaskAvailability } = useMonthlyTasks({ selectedDay });
 
-  const insets = useSafeAreaInsets(); 
-  const androidBottomOffset = Platform.OS === 'android' ? insets.bottom : 0;
+  const insets = useSafeAreaInsets();
+  const androidBottomOffset = Platform.OS === "android" ? insets.bottom : 0;
 
   // Derived values
   const selectedDateStr = format(selectedDay, "yyyy-MM-dd");
@@ -71,7 +71,7 @@ export default function MonthlyCalendarScreen() {
 
         <View className="px-2 mt-2">
           <Calendar
-            key={selectedMonthKey}
+            key={`${selectedMonthKey}-${i18n.language}`}
             current={selectedDateStr}
             onMonthChange={(month: DateData) => {
               setSelectedDay(new Date(month.year, month.month - 1, 1));
@@ -79,11 +79,11 @@ export default function MonthlyCalendarScreen() {
             hideExtraDays
             firstDay={1}
             enableSwipeMonths
-            monthFormat={"MMMM"}
             renderHeader={(date: any) => {
-              const monthIndex = date.getMonth() + 1;
+              const isChinese = i18n.language.startsWith("zh");
+              const monthName = isChinese ? `${date.getMonth() + 1}月` : format(date, "MMMM");
               return (
-                <Text className="text-4xl font-balooBold text-secondary pt-2">{`${monthIndex}月`}</Text>
+                <Text className="text-4xl font-balooBold text-secondary pt-2">{monthName}</Text>
               );
             }}
             dayComponent={renderDay}
@@ -105,8 +105,8 @@ export default function MonthlyCalendarScreen() {
         index={0}
         snapPoints={SNAP_POINTS}
         handleComponent={null}
-        bottomInset={androidBottomOffset} 
-        enableOverDrag={false} 
+        bottomInset={androidBottomOffset}
+        enableOverDrag={false}
         enableDynamicSizing={false}
         backgroundStyle={{
           backgroundColor: "white",


### PR DESCRIPTION
- Resolved an issue where the monthly calendar header remained in Chinese after switching to English.
- Fixed a persistent language display bug on Android where the "Today" button and calendar header wouldn't update after a language change.
- Increased the height of task items to provide a larger container and prevent text from being clipped in the monthly calendar bottom sheet.