### PR TITLE
improve posthog logging

### DIFF
--- a/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { View, Pressable, Text, useWindowDimensions, Keyboard } from "react-native";
 import { KeyboardStickyView, useKeyboardState } from "react-native-keyboard-controller";
 import { LinearGradient } from "expo-linear-gradient";
@@ -29,7 +29,7 @@ export default function AiTaskSheetScreen() {
   const { height } = useWindowDimensions();
   const [isAiGenerating, setIsAiGenerating] = useState(false);
   const [textInput, setTextInput] = useState("");
-  const [hasSubmittedAiRequest, setHasSubmittedAiRequest] = useState(false);
+  const hasSubmittedAiRequest = useRef(false);
   const { isVisible: isKeyboardVisible } = useKeyboardState();
   const { isHoldHintVisible, showHoldHint, hideHoldHint } = useHoldHint(1500);
   const { userInput, transcript, streamedTasks, streamedNotes, submitAudioForTranscription, sendTextMessage } = useAiTaskGenerator({
@@ -72,7 +72,7 @@ export default function AiTaskSheetScreen() {
   // --- Handlers ---
   const handleDismiss = () => {
     // Skip analytics only for passive open-and-close sessions with no submitted AI request.
-    if (!hasContent && !hasSubmittedAiRequest) {
+    if (!hasContent && !hasSubmittedAiRequest.current) {
       router.back();
       return;
     }
@@ -87,7 +87,7 @@ export default function AiTaskSheetScreen() {
   const handleSubmitText = async () => {
     if (!textInput.trim() || isAiGenerating) return;
     const message = textInput.trim();
-    setHasSubmittedAiRequest(true);
+    hasSubmittedAiRequest.current = true;
     setTextInput("");
     Keyboard.dismiss();
     await sendTextMessage(message);
@@ -119,7 +119,7 @@ export default function AiTaskSheetScreen() {
   };
 
   const handleMicPressOut = async () => {
-    setHasSubmittedAiRequest(true);
+    hasSubmittedAiRequest.current = true;
     await stopAndUpload();
   };
 

--- a/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
@@ -29,6 +29,7 @@ export default function AiTaskSheetScreen() {
   const { height } = useWindowDimensions();
   const [isAiGenerating, setIsAiGenerating] = useState(false);
   const [textInput, setTextInput] = useState("");
+  const [hasSubmittedAiRequest, setHasSubmittedAiRequest] = useState(false);
   const { isVisible: isKeyboardVisible } = useKeyboardState();
   const { isHoldHintVisible, showHoldHint, hideHoldHint } = useHoldHint(1500);
   const { userInput, transcript, streamedTasks, streamedNotes, submitAudioForTranscription, sendTextMessage } = useAiTaskGenerator({
@@ -58,12 +59,24 @@ export default function AiTaskSheetScreen() {
 
   const analyticsPayload = {
     userInput,
-    generatedTaskTitles: displayTasks.map((t) => t.title),
+    generatedTasks: displayTasks.map((task) => ({
+      title: task.title,
+      description: task.description,
+      startTime: task.startTime,
+      endTime: task.endTime,
+      ...(task.label?.name && { labelName: task.label.name }),
+    })),
     generatedNoteTexts: displayNotes.map((n) => n.text),
   };
 
   // --- Handlers ---
   const handleDismiss = () => {
+    // Skip analytics only for passive open-and-close sessions with no submitted AI request.
+    if (!hasContent && !hasSubmittedAiRequest) {
+      router.back();
+      return;
+    }
+
     analytics.trackIfUserAcceptAiTask({
       ...analyticsPayload,
       outcome: hasContent ? "rejected" : "abandoned",
@@ -74,6 +87,7 @@ export default function AiTaskSheetScreen() {
   const handleSubmitText = async () => {
     if (!textInput.trim() || isAiGenerating) return;
     const message = textInput.trim();
+    setHasSubmittedAiRequest(true);
     setTextInput("");
     Keyboard.dismiss();
     await sendTextMessage(message);
@@ -105,6 +119,7 @@ export default function AiTaskSheetScreen() {
   };
 
   const handleMicPressOut = async () => {
+    setHasSubmittedAiRequest(true);
     await stopAndUpload();
   };
 

--- a/blotztask-mobile/src/shared/services/analytics.ts
+++ b/blotztask-mobile/src/shared/services/analytics.ts
@@ -4,6 +4,14 @@ import { EVENTS, SCREEN_NAMES, type AiTaskOutcome } from "@/shared/constants/pos
 
 type ScreenName = (typeof SCREEN_NAMES)[keyof typeof SCREEN_NAMES];
 
+type AiGeneratedTaskAnalytics = {
+  title: string;
+  description: string;
+  startTime: string;
+  endTime: string;
+  labelName?: string;
+};
+
 export const analytics = {
   /**
    * Links an anonymous PostHog user to a real Auth0 identity.
@@ -62,13 +70,19 @@ export const analytics = {
   trackIfUserAcceptAiTask(params: {
     userInput?: string;
     outcome: AiTaskOutcome;
-    generatedTaskTitles: string[];
+    generatedTasks: AiGeneratedTaskAnalytics[];
     generatedNoteTexts: string[];
   }) {
     posthog.capture(EVENTS.CREATE_TASK_BY_AI, {
       ...(params.userInput !== undefined && { user_input: params.userInput }),
       outcome: params.outcome,
-      ai_generated_task_titles: params.generatedTaskTitles,
+      ai_generated_tasks: params.generatedTasks.map((task) => ({
+        title: task.title,
+        description: task.description,
+        start_time: task.startTime,
+        end_time: task.endTime,
+        ...(task.labelName && { label_name: task.labelName }),
+      })),
       ai_generated_note_texts: params.generatedNoteTexts,
     });
   },


### PR DESCRIPTION

### Summary

Improved PostHog tracking for AI task generation.

What Changed

Replaced ai_generated_task_titles with structured ai_generated_tasks.
ai_generated_tasks now includes:
title
description
start time
end time
label name
Added logic to avoid tracking when the user only opens and closes the AI dialog.
Still tracks if the user submitted text/voice but the backend returns no content.
Why

The old report did not show the AI-generated date/time, so it was hard to evaluate model accuracy. It also included noisy empty rows from users opening and closing the AI dialog without input.

Expected Behavior

Open and close without input: no PostHog row
Submit input but no AI output: abandoned
Generate preview then close: rejected
Generate preview then accept: accepted