### PR TITLE
refactor: remove defensive try/catch in service layer and strengthen global error handler

### DIFF
--- a/blotztask-mobile/src/feature/notes/services/note-time-estimate-service.ts
+++ b/blotztask-mobile/src/feature/notes/services/note-time-estimate-service.ts
@@ -5,6 +5,6 @@ import { NoteDTO } from "../models/note-dto";
 export const estimateNoteTime = async (
   floatingTask: NoteDTO,
 ): Promise<NoteTimeEstimationResult> => {
-  const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/TimeEstimate`;
+  const url = `/TimeEstimate`;
   return await apiClient.post(url, floatingTask);
 };

--- a/blotztask-mobile/src/feature/notes/services/note-time-estimate-service.ts
+++ b/blotztask-mobile/src/feature/notes/services/note-time-estimate-service.ts
@@ -5,12 +5,6 @@ import { NoteDTO } from "../models/note-dto";
 export const estimateNoteTime = async (
   floatingTask: NoteDTO,
 ): Promise<NoteTimeEstimationResult> => {
-  try {
-    const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/TimeEstimate`;
-    const taskTimeEstimation: NoteTimeEstimationResult = await apiClient.post(url, floatingTask);
-    return taskTimeEstimation;
-  } catch (error) {
-    console.error("Error estimating task time:", error);
-    throw new Error("Failed to estimate task time.");
-  }
+  const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/TimeEstimate`;
+  return await apiClient.post(url, floatingTask);
 };

--- a/blotztask-mobile/src/feature/task-details/services/subtask-service.ts
+++ b/blotztask-mobile/src/feature/task-details/services/subtask-service.ts
@@ -8,21 +8,12 @@ export const createBreakDownSubtasks = async (
   taskId: number,
 ): Promise<BreakdownResultDTO | undefined> => {
   if (!taskId) return;
-  try {
-    const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/TaskBreakdown/${taskId}`;
-    const data: BreakdownResultDTO = await apiClient.post(url);
-    return data;
-  } catch {
-    throw new Error("Error breaking down subtasks");
-  }
+  const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/TaskBreakdown/${taskId}`;
+  return await apiClient.post(url);
 };
 
 export async function addSubtask(newSubtask: AddNewSubtaskDTO): Promise<number> {
-  try {
-    return await apiClient.post<number>("/SubTask", { ...newSubtask });
-  } catch {
-    throw new Error("Add subtask failed");
-  }
+  return await apiClient.post<number>("/SubTask", { ...newSubtask });
 }
 
 
@@ -31,11 +22,7 @@ export async function updateSubtask(newSubtask: SubtaskDTO): Promise<void> {
   const subtaskId = newSubtask.subTaskId;
   const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/SubTask/tasks/${taskId}/subtasks/${subtaskId}`;
 
-  try {
-    await apiClient.put(url, { ...newSubtask });
-  } catch (err: unknown) {
-    throw new Error("Update subtask failed", { cause: err });
-  }
+  await apiClient.put(url, { ...newSubtask });
 }
 
 export async function replaceSubtasks({
@@ -47,41 +34,20 @@ export async function replaceSubtasks({
 }): Promise<void> {
   const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/SubTask/tasks/${taskId}/replaceSubtasks`;
 
-  try {
-    await apiClient.post(url, { taskId, subtasks });
-  } catch (err: unknown) {
-    console.error("Add subtasks failed:", err);
-    throw new Error("Add subtasks failed");
-  }
+  await apiClient.post(url, { taskId, subtasks });
 }
 
 export async function getSubtasksByParentId(parentId: number): Promise<SubtaskDTO[]> {
   const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/SubTask/tasks/${parentId}`;
-  try {
-    const data: SubtaskDTO[] = await apiClient.get(url);
-    return data;
-  } catch (error) {
-    console.error("Error fetching subtasks by parent ID:", error);
-    return [];
-  }
+  return await apiClient.get(url);
 }
 
 export async function deleteSubtask(subtaskId: number): Promise<void> {
   const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/SubTask/subtasks/${subtaskId}`;
-  try {
-    await apiClient.delete(url);
-  } catch (err) {
-    console.error("Error deleting subtask:", err);
-    throw new Error("Delete subtask failed");
-  }
+  await apiClient.delete(url);
 }
 
 export async function toggleSubtaskStatus(subtaskId: number): Promise<void> {
   const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/SubTask/subtask-completion-status/${subtaskId}`;
-  try {
-    await apiClient.put(url);
-  } catch (err) {
-    console.error("Error toggling subtask status:", err);
-    throw new Error("Toggle subtask status failed");
-  }
+  await apiClient.put(url);
 }

--- a/blotztask-mobile/src/feature/task-details/services/subtask-service.ts
+++ b/blotztask-mobile/src/feature/task-details/services/subtask-service.ts
@@ -8,7 +8,7 @@ export const createBreakDownSubtasks = async (
   taskId: number,
 ): Promise<BreakdownResultDTO | undefined> => {
   if (!taskId) return;
-  const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/TaskBreakdown/${taskId}`;
+  const url = `/TaskBreakdown/${taskId}`;
   return await apiClient.post(url);
 };
 
@@ -16,11 +16,10 @@ export async function addSubtask(newSubtask: AddNewSubtaskDTO): Promise<number> 
   return await apiClient.post<number>("/SubTask", { ...newSubtask });
 }
 
-
 export async function updateSubtask(newSubtask: SubtaskDTO): Promise<void> {
   const taskId = newSubtask.parentTaskId;
   const subtaskId = newSubtask.subTaskId;
-  const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/SubTask/tasks/${taskId}/subtasks/${subtaskId}`;
+  const url = `/SubTask/tasks/${taskId}/subtasks/${subtaskId}`;
 
   await apiClient.put(url, { ...newSubtask });
 }
@@ -32,22 +31,22 @@ export async function replaceSubtasks({
   taskId: number;
   subtasks: AddSubtaskDTO[];
 }): Promise<void> {
-  const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/SubTask/tasks/${taskId}/replaceSubtasks`;
+  const url = `/SubTask/tasks/${taskId}/replaceSubtasks`;
 
   await apiClient.post(url, { taskId, subtasks });
 }
 
 export async function getSubtasksByParentId(parentId: number): Promise<SubtaskDTO[]> {
-  const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/SubTask/tasks/${parentId}`;
+  const url = `/SubTask/tasks/${parentId}`;
   return await apiClient.get(url);
 }
 
 export async function deleteSubtask(subtaskId: number): Promise<void> {
-  const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/SubTask/subtasks/${subtaskId}`;
+  const url = `/SubTask/subtasks/${subtaskId}`;
   await apiClient.delete(url);
 }
 
 export async function toggleSubtaskStatus(subtaskId: number): Promise<void> {
-  const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/SubTask/subtask-completion-status/${subtaskId}`;
+  const url = `/SubTask/subtask-completion-status/${subtaskId}`;
   await apiClient.put(url);
 }

--- a/blotztask-mobile/src/shared/services/ai-usage-service.ts
+++ b/blotztask-mobile/src/shared/services/ai-usage-service.ts
@@ -2,6 +2,6 @@ import { AiUsageSummaryDTO } from "../models/ai-usage-summary-dto";
 import { apiClient } from "./api/client";
 
 export const getAiUsageSummary = async (): Promise<AiUsageSummaryDTO> => {
-  const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/ai-usage`;
+  const url = `/ai-usage`;
   return await apiClient.get<AiUsageSummaryDTO>(url);
 };

--- a/blotztask-mobile/src/shared/services/ai-usage-service.ts
+++ b/blotztask-mobile/src/shared/services/ai-usage-service.ts
@@ -3,10 +3,5 @@ import { apiClient } from "./api/client";
 
 export const getAiUsageSummary = async (): Promise<AiUsageSummaryDTO> => {
   const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/ai-usage`;
-  try {
-    const response = await apiClient.get<AiUsageSummaryDTO>(url);
-    return response;
-  } catch {
-    throw new Error("Failed to get ai usage summary.");
-  }
+  return await apiClient.get<AiUsageSummaryDTO>(url);
 };

--- a/blotztask-mobile/src/shared/services/label-service.ts
+++ b/blotztask-mobile/src/shared/services/label-service.ts
@@ -3,10 +3,5 @@ import { apiClient } from "./api/client";
 
 export const fetchAllLabel = async (): Promise<LabelDTO[]> => {
   const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/Label`;
-  try {
-    const result: LabelDTO[] = await apiClient.get(url);
-    return result;
-  } catch {
-    throw new Error("Failed to fetch labels.");
-  }
+  return await apiClient.get(url);
 };

--- a/blotztask-mobile/src/shared/services/label-service.ts
+++ b/blotztask-mobile/src/shared/services/label-service.ts
@@ -2,6 +2,6 @@ import { LabelDTO } from "../models/label-dto";
 import { apiClient } from "./api/client";
 
 export const fetchAllLabel = async (): Promise<LabelDTO[]> => {
-  const url = `${process.env.EXPO_PUBLIC_URL_WITH_API}/Label`;
+  const url = `/Label`;
   return await apiClient.get(url);
 };

--- a/blotztask-mobile/src/shared/services/task-service.ts
+++ b/blotztask-mobile/src/shared/services/task-service.ts
@@ -44,13 +44,8 @@ export async function toggleTaskCompletion(taskId: number): Promise<void> {
 }
 
 export const addTaskItem = async (addTaskForm: TaskUpsertDTO): Promise<number> => {
-  try {
-    const url = `/Task`;
-    const newTaskId: number = await apiClient.post(url, addTaskForm);
-    return newTaskId;
-  } catch {
-    throw new Error("Failed to add task.");
-  }
+  const url = `/Task`;
+  return await apiClient.post(url, addTaskForm);
 };
 
 export async function updateTaskItem(taskId: number, updatedTask: TaskUpsertDTO): Promise<void> {
@@ -66,21 +61,12 @@ export async function deleteTask(taskId: number): Promise<void> {
 
 export async function getAllTasks(): Promise<TaskDetailDTO[]> {
   const url = `/Task/all`;
-  try {
-    const data: TaskDetailDTO[] = await apiClient.get(url);
-    return data;
-  } catch {
-    throw new Error("Failed to fetch all tasks.");
-  }
+  return await apiClient.get(url);
 }
 
 export async function saveRecurringOccurrence(payload: {
   recurringTaskId: number;
   occurrenceDate: string;
 }): Promise<{ taskItemId: number }> {
-  try {
-    return await apiClient.post("/RecurringTask/occurrence/complete", payload);
-  } catch {
-    throw new Error("Failed to save recurring occurrence.");
-  }
+  return await apiClient.post("/RecurringTask/occurrence/complete", payload);
 }

--- a/blotztask-mobile/src/shared/services/user-service.ts
+++ b/blotztask-mobile/src/shared/services/user-service.ts
@@ -10,12 +10,7 @@ export const fetchUserProfile = async (): Promise<UserProfileDTO> => {
 
 export const updateUserProfile = async (userProfile: UpdateUserProfileDTO): Promise<string> => {
   const url = `/User`;
-  try {
-    return await apiClient.put<string>(url, userProfile);
-  } catch (err: unknown) {
-    console.error("Update user profile failed:", err);
-    throw new Error("Failed to update user profile data");
-  }
+  return await apiClient.put<string>(url, userProfile);
 };
 
 export const fetchUserPreferences = async (): Promise<UserPreferencesDTO> => {
@@ -26,20 +21,10 @@ export const fetchUserPreferences = async (): Promise<UserPreferencesDTO> => {
 
 export const updateUserPreferences = async (preferences: UserPreferencesDTO): Promise<string> => {
   const url = `/user-preferences`;
-  try {
-    return await apiClient.put(url, preferences);
-  } catch (err: unknown) {
-    console.error("Update user preferences failed:", err);
-    throw new Error("Failed to update user preferences");
-  }
+  return await apiClient.put(url, preferences);
 };
 
 export const deleteUser = async (): Promise<void> => {
   const url = `/User`;
-  try {
-    await apiClient.delete<void>(url);
-  } catch (err: unknown) {
-    console.error("Delete user failed:", err);
-    throw new Error("Failed to delete user");
-  }
+  await apiClient.delete<void>(url);
 };

--- a/blotztask-mobile/src/shared/util/queryClient.ts
+++ b/blotztask-mobile/src/shared/util/queryClient.ts
@@ -65,8 +65,8 @@ export const queryClient = new QueryClient({
 });
 
 function getErrorMessage(error: unknown): string {
-  if (isAxiosError(error) && !error.response) {
-    return "Unable to connect to the server.";
+  if (isAxiosError(error)) {
+    return error.response?.data?.message || "Something went wrong";
   }
   return "Something went wrong";
 }

--- a/blotztask-mobile/src/shared/util/queryClient.ts
+++ b/blotztask-mobile/src/shared/util/queryClient.ts
@@ -14,6 +14,7 @@ export const queryClient = new QueryClient({
       }
       if (query.meta?.silent) return;
 
+      if (__DEV__) console.error("[Query Error]", error);
       Sentry.captureException(error, { tags: { source: "query" } });
 
       const msg = getErrorMessage(error);
@@ -34,6 +35,7 @@ export const queryClient = new QueryClient({
       }
       if (mutation.meta?.silent) return;
 
+      if (__DEV__) console.error("[Mutation Error]", error);
       Sentry.captureException(error, { tags: { source: "mutation" } });
 
       const msg = getErrorMessage(error);
@@ -64,7 +66,7 @@ export const queryClient = new QueryClient({
 
 function getErrorMessage(error: unknown): string {
   if (isAxiosError(error) && !error.response) {
-    return "Network error. Please check your connection.";
+    return "Unable to connect to the server.";
   }
   return "Something went wrong";
 }

--- a/blotztask-mobile/src/shared/util/queryClient.ts
+++ b/blotztask-mobile/src/shared/util/queryClient.ts
@@ -26,6 +26,12 @@ export const queryClient = new QueryClient({
   }),
   mutationCache: new MutationCache({
     onError: (error, _variables, _context, mutation) => {
+      if (
+        isAxiosError(error) &&
+        (error.response?.status === 401 || error.response?.status === 403)
+      ) {
+        return;
+      }
       if (mutation.meta?.silent) return;
 
       Sentry.captureException(error, { tags: { source: "mutation" } });
@@ -36,9 +42,6 @@ export const queryClient = new QueryClient({
         type: "error",
         text1: msg,
       });
-    },
-    onSuccess: (data, variables) => {
-      console.log("[Mutation Success]", data, variables);
     },
   }),
   defaultOptions: {
@@ -60,13 +63,8 @@ export const queryClient = new QueryClient({
 });
 
 function getErrorMessage(error: unknown): string {
-  if (isAxiosError(error)) {
-    return error.response?.data?.message || "Something went wrong";
+  if (isAxiosError(error) && !error.response) {
+    return "Network error. Please check your connection.";
   }
-
-  if (error instanceof Error) {
-    return error.message;
-  }
-
   return "Something went wrong";
 }


### PR DESCRIPTION
refactor: remove defensive try/catch in service layer and strengthen global error handler

Service functions were catching AxiosError and rethrowing generic Error("Failed to ..."),
which stripped HTTP status, URL, and response body before reaching the global handler.
This broke the 401/403 skip logic, made Sentry reports useless, and hid real errors.

Changes:
- Remove try/catch wrappers in 16 service functions across 6 files
- Add 401/403 skip to mutationCache.onError (was only on queryCache)
- Simplify getErrorMessage to show fixed user-friendly messages only
- Remove console.log from mutationCache.onSuccess