### PR TITLE
refactor: simplify async handling in various components

### DIFF
--- a/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
@@ -110,22 +110,21 @@ export default function AiTaskSheetScreen() {
 
   const handleAddAll = async () => {
     if (isAdding || isNoteCreating) return;
-    try {
-      await Promise.all([
-        ...displayTasks.map((task) => addTaskAsync(convertAiTaskToTaskUpsertDTO(task))),
-        ...displayNotes.map((n) => createNoteAsync(n.text)),
-      ]);
-      analytics.trackAiTaskGenerationSession({
-        outcome: "accepted",
-        turns,
-      });
+
+    const results = await Promise.allSettled([
+      ...displayTasks.map((task) => addTaskAsync(convertAiTaskToTaskUpsertDTO(task))),
+      ...displayNotes.map((n) => createNoteAsync(n.text)),
+    ]);
+
+    const allSucceeded = results.every((r) => r.status === "fulfilled");
+
+    if (allSucceeded) {
+      analytics.trackAiTaskGenerationSession({ outcome: "accepted", turns });
       router.back();
       // Delay the toast slightly to ensure it appears after the sheet has fully closed
       requestIdleCallback(() => Toast.show({ type: "warning", text1: t("success.taskAdded") }));
-    } catch {
-      // Each failed mutation is already handled by the global mutationCache.onError (toast + Sentry).
-      // Catch here only to prevent unhandled rejection from Promise.all.
     }
+    // Failed mutations are already handled by the global mutationCache.onError (toast + Sentry).
   };
 
   const handleMicPressIn = () => {

--- a/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
@@ -117,8 +117,9 @@ export default function AiTaskSheetScreen() {
       router.back();
       // Delay the toast slightly to ensure it appears after the sheet has fully closed
       requestIdleCallback(() => Toast.show({ type: "warning", text1: t("success.taskAdded") }));
-    } catch (error) {
-      console.error("Add tasks/notes failed", error);
+    } catch {
+      // Each failed mutation is already handled by the global mutationCache.onError (toast + Sentry).
+      // Catch here only to prevent unhandled rejection from Promise.all.
     }
   };
 

--- a/blotztask-mobile/src/feature/calendar/components/subtask-list.tsx
+++ b/blotztask-mobile/src/feature/calendar/components/subtask-list.tsx
@@ -31,8 +31,8 @@ const SubtaskList = ({ task, progress }: Props) => {
     overflow: "hidden",
   }));
 
-  const handleToggleSubtask = async (subtaskId: number) => {
-    await toggleSubtaskStatus({ subtaskId, parentTaskId: task.id });
+  const handleToggleSubtask = (subtaskId: number) => {
+    toggleSubtaskStatus({ subtaskId, parentTaskId: task.id });
   };
 
   const onSubtaskContentLayout = (e: LayoutChangeEvent) => {

--- a/blotztask-mobile/src/feature/calendar/components/task-card.tsx
+++ b/blotztask-mobile/src/feature/calendar/components/task-card.tsx
@@ -76,18 +76,16 @@ const TaskCard = ({ task, deleteTask, isDeleting, selectedDay, onOpenMode }: Tas
     router.push({ pathname: "/(protected)/task-details", params: { taskId: task.id } });
   };
 
-  const handleBreakdown = async () => {
+  const handleBreakdown = () => {
     if (isLoading || task.id == null) return;
-
-    try {
-      const result = await breakDownAndReplaceSubtasks(task.id);
-      if (result?.subtasks?.length) {
-        setIsExpanded(true);
-        swipeRef.current?.close();
-      }
-    } catch (e) {
-      console.error("Breakdown error:", e);
-    }
+    breakDownAndReplaceSubtasks(task.id, {
+      onSuccess: (result) => {
+        if (result?.subtasks?.length) {
+          setIsExpanded(true);
+          swipeRef.current?.close();
+        }
+      },
+    });
   };
 
   const handleDelete = async () => {

--- a/blotztask-mobile/src/feature/settings/screens/settings-avatar-screen.tsx
+++ b/blotztask-mobile/src/feature/settings/screens/settings-avatar-screen.tsx
@@ -14,10 +14,10 @@ export default function SettingsAvatarScreen() {
   const avatars = LOCAL_AVATARS;
   const { updateUserProfile, isUserUpdating } = useUserProfileMutation();
 
-  const handleAvatarSelect = async (avatar: AvatarDTO) => {
+  const handleAvatarSelect = (avatar: AvatarDTO) => {
     if (isUserUpdating) return;
 
-    await updateUserProfile({
+    updateUserProfile({
       displayName: userProfile?.displayName ?? "",
       pictureUrl: avatar.id,
       isOnBoarded: userProfile?.isOnBoarded ?? false,

--- a/blotztask-mobile/src/feature/settings/screens/settings-language-screen.tsx
+++ b/blotztask-mobile/src/feature/settings/screens/settings-language-screen.tsx
@@ -21,15 +21,10 @@ export default function SettingsLanguageScreen() {
     const i18nLang = language === Language.En ? "en" : "zh";
     await i18n.changeLanguage(i18nLang);
 
-    try {
-      await updateUserPreferences({
-        ...userPreferences,
-        preferredLanguage: language,
-      });
-      console.log(`Language updated to: ${language}`);
-    } catch (error) {
-      console.log("Failed to update language:", error);
-    }
+    updateUserPreferences({
+      ...userPreferences,
+      preferredLanguage: language,
+    });
   };
 
   if (isUserPreferencesLoading) {

--- a/blotztask-mobile/src/feature/settings/screens/settings-update-user-name-screen.tsx
+++ b/blotztask-mobile/src/feature/settings/screens/settings-update-user-name-screen.tsx
@@ -16,14 +16,12 @@ export default function SettingsUpdateUserNameScreen() {
 
   const { updateUserProfile: updateUser, isUserUpdating } = useUserProfileMutation();
 
-  const handleUpdate = async () => {
+  const handleUpdate = () => {
     if (!enableDoneButton || isUserUpdating) return;
-    try {
-      await updateUser({ displayName: name.trim(), pictureUrl: userProfile?.pictureUrl ?? "" });
-      router.back();
-    } catch (e) {
-      console.log("Failed to update user name:", e);
-    }
+    updateUser(
+      { displayName: name.trim(), pictureUrl: userProfile?.pictureUrl ?? "" },
+      { onSuccess: () => router.back() },
+    );
   };
 
   return (

--- a/blotztask-mobile/src/feature/task-add-edit/screens/task-create-screen.tsx
+++ b/blotztask-mobile/src/feature/task-add-edit/screens/task-create-screen.tsx
@@ -13,18 +13,14 @@ export default function TaskCreateScreen() {
   const { addTask, isAdding } = useTaskMutations();
   const { t } = useTranslation("tasks");
 
-  const handleTaskSubmit = async (submitTask: TaskUpsertDTO) => {
-    try {
-      await addTask(submitTask);
-
-      analytics.trackManualTaskCreated();
-
-      router.back();
-      Toast.show({ type: "warning", text1: t("success.taskCreated") });
-      console.log("Task created successfully");
-    } catch (error) {
-      console.error("Failed to create task:", error);
-    }
+  const handleTaskSubmit = (submitTask: TaskUpsertDTO) => {
+    addTask(submitTask, {
+      onSuccess: () => {
+        analytics.trackManualTaskCreated();
+        router.back();
+        Toast.show({ type: "warning", text1: t("success.taskCreated") });
+      },
+    });
   };
 
   if (isAdding) {

--- a/blotztask-mobile/src/feature/task-add-edit/screens/task-edit-screen.tsx
+++ b/blotztask-mobile/src/feature/task-add-edit/screens/task-edit-screen.tsx
@@ -9,7 +9,7 @@ import { View } from "react-native";
 import { ReturnButton } from "@/shared/components/return-button";
 
 export default function TaskEditScreen() {
-  const { updateTaskAsync, isUpdating } = useTaskMutations();
+  const { updateTask, isUpdating } = useTaskMutations();
   const params = useLocalSearchParams<{ taskId: string }>();
   const taskId = Number(params.taskId ?? "");
   const { selectedTask, isLoading, isFetching } = useTaskById({ taskId });
@@ -33,17 +33,11 @@ export default function TaskEditScreen() {
     dueAt: selectedTask.dueAt,
   };
 
-  const handleTaskSubmit = async (formValues: TaskUpsertDTO) => {
-    try {
-      await updateTaskAsync({
-        taskId: selectedTask.id,
-        dto: formValues,
-      });
-
-      router.back();
-    } catch (error) {
-      console.error("Failed to submit task:", error);
-    }
+  const handleTaskSubmit = (formValues: TaskUpsertDTO) => {
+    updateTask(
+      { taskId: selectedTask.id, dto: formValues },
+      { onSuccess: () => router.back() },
+    );
   };
 
   return (

--- a/blotztask-mobile/src/feature/task-details/components/subtasks-editor.tsx
+++ b/blotztask-mobile/src/feature/task-details/components/subtasks-editor.tsx
@@ -7,12 +7,9 @@ import { useSubtaskMutations } from "../hooks/useSubtaskMutations";
 import { useSubtasksByParentId } from "@/feature/task-details/hooks/useSubtasksByParentId";
 import { DraggableSubtaskList } from "@/feature/task-details/components/draggable-subtask-list";
 import { TaskDetailDTO } from "@/shared/models/task-detail-dto";
-import Toast from "react-native-toast-message";
-import { BreakdownResultDTO } from "../models/breakdown-result-dto";
-
 type SubtasksEditorProps = {
   parentTask: TaskDetailDTO;
-  onRefreshSubtasks: () => Promise<BreakdownResultDTO | undefined>;
+  onRefreshSubtasks: () => void;
   isRefreshingSubtasks: boolean;
 };
 
@@ -29,24 +26,16 @@ const SubtasksEditor = ({ parentTask, onRefreshSubtasks, isRefreshingSubtasks }:
     setIsEditMode(false);
   };
 
-  const handleRefresh = async () => {
-    await onRefreshSubtasks();
+  const handleRefresh = () => {
+    onRefreshSubtasks();
   };
 
   const handleEdit = () => {
     setIsEditMode(!isEditMode);
   };
 
-  const handleDelete = async (id: number) => {
-    try {
-      await deleteSubtask({ subtaskId: id, parentTaskId: parentTask.id! });
-    } catch (error) {
-      console.error("Failed to delete subtask:", error);
-      Toast.show({
-        type: "error",
-        text1: t("tasks:details.failedToDeleteSubtask"),
-      });
-    }
+  const handleDelete = (id: number) => {
+    deleteSubtask({ subtaskId: id, parentTaskId: parentTask.id! });
   };
 
   const handleAddSubtask = async () => {

--- a/blotztask-mobile/src/feature/task-details/components/subtasks-view.tsx
+++ b/blotztask-mobile/src/feature/task-details/components/subtasks-view.tsx
@@ -22,10 +22,9 @@ const SubtasksView = ({ parentTask }: SubtaskViewProps) => {
   const displaySubtasks = fetchedSubtasks || [];
   const hasSubtasks = displaySubtasks.length > 0;
 
-  const handleBreakDown = async () => {
+  const handleBreakDown = () => {
     if (isBreakingDownAndReplacingSubtasks || parentTask.id == null) return;
-
-    return await breakDownAndReplaceSubtasks(parentTask.id);
+    breakDownAndReplaceSubtasks(parentTask.id);
   };
 
   const isLoading = isBreakingDownAndReplacingSubtasks || isLoadingSubtasks;

--- a/blotztask-mobile/src/feature/task-details/hooks/useSubtaskMutations.ts
+++ b/blotztask-mobile/src/feature/task-details/hooks/useSubtaskMutations.ts
@@ -16,9 +16,6 @@ export const useSubtaskMutations = () => {
 
   const breakdownMutation = useMutation<BreakdownResultDTO | undefined, void, number>({
     mutationFn: createBreakDownSubtasks,
-    onError: (error) => {
-      console.error("Failed to create subtasks:", error);
-    },
   });
 
   const breakDownAndReplaceSubtasksMutation = useMutation<
@@ -58,12 +55,8 @@ export const useSubtaskMutations = () => {
     mutationFn: ({ subtaskId, parentTaskId }: { subtaskId: number; parentTaskId: number }) =>
       deleteSubtask(subtaskId),
     onSuccess: (_, variables) => {
-      console.log("Deleted subtask", variables.subtaskId);
       queryClient.invalidateQueries({ queryKey: subtaskKeys.all(variables.parentTaskId) });
       queryClient.invalidateQueries({ queryKey: taskKeys.all });
-    },
-    onError: (error) => {
-      console.error("Failed to delete subtask:", error);
     },
   });
 
@@ -72,9 +65,6 @@ export const useSubtaskMutations = () => {
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: subtaskKeys.all(variables.parentTaskId) });
       queryClient.invalidateQueries({ queryKey: taskKeys.all });
-    },
-    onError: (error) => {
-      console.error("Failed to update subtask:", error);
     },
   });
 
@@ -93,25 +83,22 @@ export const useSubtaskMutations = () => {
       queryClient.invalidateQueries({ queryKey: subtaskKeys.all(variables.parentTaskId) });
       queryClient.invalidateQueries({ queryKey: taskKeys.all });
     },
-    onError: (error) => {
-      console.error("Failed to toggle subtask status:", error);
-    },
   });
 
   return {
     // Breakdown
-    breakDownTask: breakdownMutation.mutateAsync,
+    breakDownTask: breakdownMutation.mutate,
     isBreakingDown: breakdownMutation.isPending,
 
-    breakDownAndReplaceSubtasks: breakDownAndReplaceSubtasksMutation.mutateAsync,
+    breakDownAndReplaceSubtasks: breakDownAndReplaceSubtasksMutation.mutate,
     isBreakingDownAndReplacingSubtasks: breakDownAndReplaceSubtasksMutation.isPending,
 
     // Delete subtask
-    deleteSubtask: deleteSubtaskMutation.mutateAsync,
+    deleteSubtask: deleteSubtaskMutation.mutate,
     isDeletingSubtask: deleteSubtaskMutation.isPending,
 
-    //Update subtask
-    updateSubtask: updateSubtaskMutation.mutateAsync,
+    // Update subtask
+    updateSubtask: updateSubtaskMutation.mutate,
     isUpdatingSubtask: updateSubtaskMutation.isPending,
 
     // Add subtask
@@ -119,7 +106,7 @@ export const useSubtaskMutations = () => {
     isAddingSubtask: addSubtaskMutation.isPending,
 
     // Toggle subtask status
-    toggleSubtaskStatus: toggleSubtaskStatusMutation.mutateAsync,
+    toggleSubtaskStatus: toggleSubtaskStatusMutation.mutate,
     isTogglingSubtaskStatus: toggleSubtaskStatusMutation.isPending,
   };
 };


### PR DESCRIPTION
Screen layer used `mutateAsync` + `try/catch` where catch blocks only did console.error or nothing — redundant with the global handler. Worse, some screens called `.mutate` (returns void) with await, so `try/catch` never caught anything and success logic like `router.back()` ran unconditionally regardless of mutation outcome.

Switched 11 files to `.mutate(payload, { onSuccess })` callback pattern. Success side-effects are now gated behind actual success. Removed redundant `onError` handlers from hooks. Kept `mutateAsync` only where `Promise.all` requires it.