### PR TITLE
Fix weekly review comment

### DIFF
--- a/blotztask-api/Modules/Reviews/Commands/GenerateReview.cs
+++ b/blotztask-api/Modules/Reviews/Commands/GenerateReview.cs
@@ -75,16 +75,7 @@ public class GenerateReviewCommandHandler(
                 "Returning existing {PeriodType} review for user {UserId} ({StartLocal}, {TimeZoneId})",
                 period.PeriodType, command.UserId, period.StartLocalDate, period.TimeZoneId);
 
-            return new ReviewReportDto
-            {
-                PeriodType = period.PeriodType,
-                PeriodStartLocal = period.StartLocalDate,
-                PeriodEndLocalExclusive = period.EndLocalDateExclusive,
-                Letter = existingReport.AiGeneratedLetter,
-                GeneratedAtUtc = DateTime.SpecifyKind(existingReport.CreatedAt, DateTimeKind.Utc),
-                IsLowActivity = existingReport.AiInputTaskCount != null
-                                && existingReport.AiInputTaskCount < threshold,
-            };
+            return MapToDto(existingReport, period, threshold);
         }
 
         // A review is a period-end summary, so it is only available once the period has fully ended
@@ -128,22 +119,52 @@ public class GenerateReviewCommandHandler(
         };
 
         db.ReviewReports.Add(report);
-        await db.SaveChangesAsync(ct);
+        try
+        {
+            await db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException)
+        {
+            // Concurrency guard: two simultaneous requests can both pass the existence check above
+            // and generate, but the unique index (UserId, PeriodType, PeriodStartUtc) lets only one
+            // insert win. Rather than surface a 500 to the loser, detach our rejected row and return
+            // the winner's report. (We accept the rare duplicate AI call — it's cheap.)
+            db.Entry(report).State = EntityState.Detached;
+
+            var winningReport = await db.ReviewReports
+                .AsNoTracking()
+                .FirstOrDefaultAsync(
+                    r => r.UserId == command.UserId
+                         && r.PeriodType == period.PeriodType
+                         && r.PeriodStartUtc == period.StartUtc,
+                    ct);
+
+            if (winningReport is null) throw;
+
+            logger.LogInformation(
+                "Concurrent {PeriodType} review insert for user {UserId} lost the race; returning the existing report",
+                period.PeriodType, command.UserId);
+
+            return MapToDto(winningReport, period, threshold);
+        }
 
         logger.LogInformation(
             "Saved {PeriodType} review {ReportId} for user {UserId} ({StartLocal}, {TimeZoneId})",
             period.PeriodType, report.Id, command.UserId, period.StartLocalDate, period.TimeZoneId);
 
-        return new ReviewReportDto
+        return MapToDto(report, period, threshold);
+    }
+
+    private static ReviewReportDto MapToDto(ReviewReport report, ReviewPeriod period, int threshold) =>
+        new()
         {
             PeriodType = period.PeriodType,
             PeriodStartLocal = period.StartLocalDate,
             PeriodEndLocalExclusive = period.EndLocalDateExclusive,
             Letter = report.AiGeneratedLetter,
             GeneratedAtUtc = DateTime.SpecifyKind(report.CreatedAt, DateTimeKind.Utc),
-            IsLowActivity = tasks.Count < threshold,
+            IsLowActivity = report.AiInputTaskCount != null && report.AiInputTaskCount < threshold,
         };
-    }
 
     private Task<List<ReviewTaskDto>> LoadTasksForPeriodAsync(
         Guid userId,

--- a/blotztask-mobile/src/app/(protected)/(tabs)/settings/review.tsx
+++ b/blotztask-mobile/src/app/(protected)/(tabs)/settings/review.tsx
@@ -1,5 +1,5 @@
-import MonthlyReviewScreen from "@/feature/review/screens/monthly-review-screen";
+import ReviewScreen from "@/feature/review/screens/review-screen";
 
 export default function ReviewRoute() {
-  return <MonthlyReviewScreen />;
+  return <ReviewScreen />;
 }

--- a/blotztask-mobile/src/feature/review/components/period-selector.tsx
+++ b/blotztask-mobile/src/feature/review/components/period-selector.tsx
@@ -8,7 +8,7 @@ type Props = {
   disableNext: boolean;
 };
 
-export function MonthSelector({ label, onPrev, onNext, disablePrev, disableNext }: Props) {
+export function PeriodSelector({ label, onPrev, onNext, disablePrev, disableNext }: Props) {
   return (
     <View className="bg-white rounded-full flex-row items-center justify-between px-2 py-2">
       <Pressable

--- a/blotztask-mobile/src/feature/review/components/review-coming-soon.tsx
+++ b/blotztask-mobile/src/feature/review/components/review-coming-soon.tsx
@@ -8,7 +8,7 @@ type Props = {
   body?: string;
 };
 
-export function MonthlyReviewComingSoon({ title, body }: Props) {
+export function ReviewComingSoon({ title, body }: Props) {
   const { t } = useTranslation("settings");
 
   return (

--- a/blotztask-mobile/src/feature/review/components/review-header.tsx
+++ b/blotztask-mobile/src/feature/review/components/review-header.tsx
@@ -10,7 +10,7 @@ type Props = {
   title?: string;
 };
 
-export function MonthlyReviewHeader({ onBack, showShare, isSharing, onShare, title }: Props) {
+export function ReviewHeader({ onBack, showShare, isSharing, onShare, title }: Props) {
   const { t } = useTranslation("settings");
 
   return (

--- a/blotztask-mobile/src/feature/review/components/review-tip-banner.tsx
+++ b/blotztask-mobile/src/feature/review/components/review-tip-banner.tsx
@@ -6,7 +6,7 @@ type Props = {
   onDismiss?: () => void;
 };
 
-export function MonthlyReviewTipBanner({ text, onDismiss }: Props) {
+export function ReviewTipBanner({ text, onDismiss }: Props) {
   return (
     <View className="mb-4 w-full flex-row items-start rounded-2xl border border-[#DCEFC9] bg-[#F2F9EA] px-3.5 py-3 shadow-sm shadow-black/[.03]">
       <View className="mt-0.5 h-7 w-7 items-center justify-center rounded-full bg-[#DDF1CB]">

--- a/blotztask-mobile/src/feature/review/components/weekly-review-view.tsx
+++ b/blotztask-mobile/src/feature/review/components/weekly-review-view.tsx
@@ -5,9 +5,9 @@ import { addWeeks, format, isAfter, isSameWeek, subWeeks } from "date-fns";
 import { useUserProfile } from "@/shared/hooks/useUserProfile";
 import { LetterCardContent } from "./letter-card-content";
 import { LetterHeader } from "./letter-header";
-import { MonthlyReviewComingSoon } from "./monthly-review-coming-soon";
-import { MonthlyReviewTipBanner } from "./monthly-review-tip-banner";
-import { MonthSelector } from "./month-selector";
+import { ReviewComingSoon } from "./review-coming-soon";
+import { ReviewTipBanner } from "./review-tip-banner";
+import { PeriodSelector } from "./period-selector";
 import { useReview } from "../hooks/useReviewReport";
 import { ReviewPeriodType } from "../models/review-dto";
 import { formatWeek, startOfReviewWeek } from "../utils/week-utils";
@@ -68,7 +68,7 @@ export function WeeklyReviewView({ shareCardRef, onShareAvailableChange }: Props
 
   if (hasNoReviewableWeek) {
     return (
-      <MonthlyReviewComingSoon
+      <ReviewComingSoon
         title={t("weeklyReview.comingSoonTitle")}
         body={t("weeklyReview.comingSoonBody")}
       />
@@ -78,7 +78,7 @@ export function WeeklyReviewView({ shareCardRef, onShareAvailableChange }: Props
   return (
     <>
       <View className="px-5 mb-4">
-        <MonthSelector
+        <PeriodSelector
           label={displayWeek}
           onPrev={handlePrevWeek}
           onNext={handleNextWeek}
@@ -90,7 +90,7 @@ export function WeeklyReviewView({ shareCardRef, onShareAvailableChange }: Props
       <ScrollView contentContainerStyle={{ paddingBottom: 48 }}>
         <View className="px-5">
           {showLowActivityTip && (
-            <MonthlyReviewTipBanner
+            <ReviewTipBanner
               text={t("weeklyReview.lowActivityHint")}
               onDismiss={() => setIsTipDismissed(true)}
             />

--- a/blotztask-mobile/src/feature/review/hooks/useReviewShare.ts
+++ b/blotztask-mobile/src/feature/review/hooks/useReviewShare.ts
@@ -9,7 +9,7 @@ type Params = {
   captureTargetRef: RefObject<View | null>;
 };
 
-export function useMonthlyReviewShare({ captureTargetRef }: Params) {
+export function useReviewShare({ captureTargetRef }: Params) {
   const { t } = useTranslation("settings");
 
   const [isSharingImage, setIsSharingImage] = useState(false);

--- a/blotztask-mobile/src/feature/review/screens/review-screen.tsx
+++ b/blotztask-mobile/src/feature/review/screens/review-screen.tsx
@@ -7,18 +7,18 @@ import { addMonths, format, isAfter, isSameMonth, startOfMonth, subMonths } from
 import { useUserProfile } from "@/shared/hooks/useUserProfile";
 import { LetterCardContent } from "../components/letter-card-content";
 import { LetterHeader } from "../components/letter-header";
-import { MonthSelector } from "../components/month-selector";
-import { MonthlyReviewComingSoon } from "../components/monthly-review-coming-soon";
-import { MonthlyReviewHeader } from "../components/monthly-review-header";
-import { MonthlyReviewTipBanner } from "../components/monthly-review-tip-banner";
+import { PeriodSelector } from "../components/period-selector";
+import { ReviewComingSoon } from "../components/review-coming-soon";
+import { ReviewHeader } from "../components/review-header";
+import { ReviewTipBanner } from "../components/review-tip-banner";
 import { ReviewTab, ReviewTabs } from "../components/review-tabs";
 import { WeeklyReviewView } from "../components/weekly-review-view";
 import { useReview } from "../hooks/useReviewReport";
-import { useMonthlyReviewShare } from "../hooks/useMonthlyReviewShare";
+import { useReviewShare } from "../hooks/useReviewShare";
 import { ReviewPeriodType } from "../models/review-dto";
 import { formatMonth } from "../utils/month-utils";
 
-export default function MonthlyReviewScreen() {
+export default function ReviewScreen() {
   // — Hooks ——————————————————————————————————————————————————————
   const router = useRouter();
   const { t, i18n } = useTranslation("settings");
@@ -36,7 +36,7 @@ export default function MonthlyReviewScreen() {
   // — Derived values —————————————————————————————————————————————
   const isMonthlyTab = activeTab === ReviewPeriodType.Monthly;
   const activeShareCardRef = isMonthlyTab ? monthlyShareCardRef : weeklyShareCardRef;
-  const { isSharingImage, shareImage } = useMonthlyReviewShare({
+  const { isSharingImage, shareImage } = useReviewShare({
     captureTargetRef: activeShareCardRef,
   });
   // Don't let users page back before sign-up month — those months are always empty.
@@ -83,7 +83,7 @@ export default function MonthlyReviewScreen() {
 
   return (
     <SafeAreaView className="flex-1 bg-background">
-      <MonthlyReviewHeader
+      <ReviewHeader
         title={t("review.title")}
         onBack={() => router.back()}
         showShare={showShareButton}
@@ -101,11 +101,11 @@ export default function MonthlyReviewScreen() {
           onShareAvailableChange={setIsWeeklyShareAvailable}
         />
       ) : hasNoReviewableMonth ? (
-        <MonthlyReviewComingSoon />
+        <ReviewComingSoon />
       ) : (
         <>
           <View className="px-5 mb-4">
-            <MonthSelector
+            <PeriodSelector
               label={displayMonth}
               onPrev={handlePrevMonth}
               onNext={handleNextMonth}
@@ -116,7 +116,7 @@ export default function MonthlyReviewScreen() {
           <ScrollView contentContainerStyle={{ paddingBottom: 48 }}>
             <View className="px-5">
               {showLowActivityTip && (
-                <MonthlyReviewTipBanner
+                <ReviewTipBanner
                   text={t("monthlyReview.lowActivityHint")}
                   onDismiss={() => setIsTipDismissed(true)}
                 />


### PR DESCRIPTION
## Summary

Problem: Two requests for the same period could both pass the existing-report check and both insert. The unique index blocked the duplicate row, but the losing request crashed with a 500.

Fix: Wrapped the save in try/catch (DbUpdateException). On conflict, the loser returns the winner's report instead of erroring. Mirrors the RecurringOccurrenceMaterializer pattern. Also extracted a shared MapToDto helper.

Note: Duplicate AI call left as-is — cheap, and the frontend guards against double-triggers.

## Release note

<!--
Write ONE sentence a normal user would understand — or "none".
Then tick exactly ONE status below. This feeds the user-facing release notes
("What's New"), so please be accurate about whether users actually see this.
-->

> _your one-line user-facing note here, or "none"_

**Status:**

- [ ] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [x] Internal only (refactor / infra / tests / CI / deps) — don't announce
