### PR TITLE
Add recurring task beta tips

### DIFF
--- a/blotztask-mobile/src/feature/task-add-edit/components/recurrence-select.tsx
+++ b/blotztask-mobile/src/feature/task-add-edit/components/recurrence-select.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Text } from "react-native";
+import { Text, View } from "react-native";
 import { Controller, Control } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import Animated from "react-native-reanimated";
@@ -32,7 +32,14 @@ export const RecurrenceSelect = ({ control }: RecurrenceSelectProps) => {
           className="flex-row items-center justify-between"
           layout={MotionAnimations.layout}
         >
-          <Text className="font-baloo text-secondary text-xl mt-1">{t("form.repeat")}</Text>
+          <View className="flex-row items-center mt-1">
+            <Text className="font-baloo text-secondary text-xl">{t("form.repeat")}</Text>
+            <View className="ml-2 rounded-full bg-lime-100 px-2 py-0.5">
+              <Text className="font-balooBold text-[11px] uppercase text-highlight">
+                {t("form.repeatBeta")}
+              </Text>
+            </View>
+          </View>
           <AnimatedDropdown
             value={value}
             onChange={onChange}

--- a/blotztask-mobile/src/feature/task-add-edit/screens/task-create-screen.tsx
+++ b/blotztask-mobile/src/feature/task-add-edit/screens/task-create-screen.tsx
@@ -9,6 +9,7 @@ import { analytics } from "@/shared/services/analytics";
 import Toast from "react-native-toast-message";
 import { useTranslation } from "react-i18next";
 import { TaskTimeType } from "@/shared/models/base-task-dto";
+import { getWeeklyDayFlag } from "@/feature/task-add-edit/util/get-weekly-day-flag";
 
 export default function TaskCreateScreen() {
   const router = useRouter();
@@ -90,11 +91,4 @@ function mapTaskToRecurringTask(task: TaskUpsertDTO): RecurringTaskCreateDTO | n
 
 function toDateOnly(dateTimeOffset: string): string {
   return dateTimeOffset.slice(0, 10);
-}
-
-function getWeeklyDayFlag(dateOnly: string): number {
-  const [year, month, dayOfMonth] = dateOnly.split("-").map(Number);
-  const day = new Date(year, month - 1, dayOfMonth).getDay();
-  const dayFlags = [64, 1, 2, 4, 8, 16, 32] as const;
-  return dayFlags[day];
 }

--- a/blotztask-mobile/src/feature/task-add-edit/screens/task-edit-screen.tsx
+++ b/blotztask-mobile/src/feature/task-add-edit/screens/task-edit-screen.tsx
@@ -25,6 +25,7 @@ import { RecurrenceFrequency } from "@/shared/models/recurring-task-create-dto";
 import { ActionChoiceSheet } from "@/shared/components/action-choice-sheet";
 import { labelKeys, taskKeys } from "@/shared/constants/query-key-factory";
 import { LabelDTO } from "@/shared/models/label-dto";
+import { getWeeklyDayFlag } from "@/feature/task-add-edit/util/get-weekly-day-flag";
 
 function selectTaskByRouteMode({
   mode,
@@ -462,11 +463,4 @@ function mapFormValuesToRecurringMetadata(
     startDate: currentTask.recurringTask?.startDate ?? currentTask.startTime,
     endDate: formValues.recurrenceEndDate ?? null,
   };
-}
-
-function getWeeklyDayFlag(dateOnly: string): number {
-  const [year, month, dayOfMonth] = dateOnly.split("-").map(Number);
-  const day = new Date(year, month - 1, dayOfMonth).getDay();
-  const dayFlags = [64, 1, 2, 4, 8, 16, 32] as const;
-  return dayFlags[day];
 }

--- a/blotztask-mobile/src/feature/task-add-edit/util/get-weekly-day-flag.ts
+++ b/blotztask-mobile/src/feature/task-add-edit/util/get-weekly-day-flag.ts
@@ -1,0 +1,6 @@
+export function getWeeklyDayFlag(dateOnly: string): number {
+  const [year, month, dayOfMonth] = dateOnly.split("-").map(Number);
+  const day = new Date(year, month - 1, dayOfMonth).getDay();
+  const dayFlags = [64, 1, 2, 4, 8, 16, 32] as const;
+  return dayFlags[day];
+}

--- a/blotztask-mobile/src/i18n/locales/en/tasks.json
+++ b/blotztask-mobile/src/i18n/locales/en/tasks.json
@@ -8,6 +8,7 @@
     "event": "Event",
     "alert": "Alert",
     "repeat": "Repeat",
+    "repeatBeta": "Beta",
     "category": "Category",
     "noCategory": "No Category",
     "date": "Date",

--- a/blotztask-mobile/src/i18n/locales/zh/tasks.json
+++ b/blotztask-mobile/src/i18n/locales/zh/tasks.json
@@ -8,6 +8,7 @@
     "event": "事件",
     "alert": "提醒",
     "repeat": "重复",
+    "repeatBeta": "测试版",
     "category": "分类",
     "noCategory": "无分类",
     "date": "日期",


### PR DESCRIPTION
## Summary

- Adds a localized Beta badge next to the Repeat field in the task form so users can tell recurring tasks are still in beta.
- Extracts the weekly day flag calculation into a shared task-add-edit utility used by both create and edit task flows.

## Release note

> The Repeat field is now marked as Beta while recurring tasks continue to roll out.

**Status:**

- [ ] User-facing — announce it
- [x] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce