### PR TITLE
fix relogin issue using auth0 lib packages for refresh token

### DIFF
--- a/blotztask-mobile/app.config.js
+++ b/blotztask-mobile/app.config.js
@@ -44,7 +44,6 @@ export default {
     },
     plugins: [
       "expo-router",
-      "expo-secure-store",
       [
         "expo-dev-client",
         {

--- a/blotztask-mobile/package-lock.json
+++ b/blotztask-mobile/package-lock.json
@@ -45,7 +45,6 @@
         "expo-localization": "~56.0.6",
         "expo-notifications": "~56.0.13",
         "expo-router": "~56.2.6",
-        "expo-secure-store": "~56.0.4",
         "expo-sensors": "~56.0.5",
         "expo-sharing": "~56.0.14",
         "expo-splash-screen": "~56.0.10",
@@ -8314,15 +8313,6 @@
         "react-server-dom-webpack": {
           "optional": true
         }
-      }
-    },
-    "node_modules/expo-secure-store": {
-      "version": "56.0.4",
-      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-56.0.4.tgz",
-      "integrity": "sha512-hjEi/gmpdFFJ9lYbdp3k3p/WchV7Gi0Qt8jt/m/0WJadqQrskafHAlDxbZkII1cN3Yd7zp9Lvkeq3UfGhSwirQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*"
       }
     },
     "node_modules/expo-sensors": {

--- a/blotztask-mobile/package.json
+++ b/blotztask-mobile/package.json
@@ -49,7 +49,6 @@
     "expo-localization": "~56.0.6",
     "expo-notifications": "~56.0.13",
     "expo-router": "~56.2.6",
-    "expo-secure-store": "~56.0.4",
     "expo-sensors": "~56.0.5",
     "expo-sharing": "~56.0.14",
     "expo-splash-screen": "~56.0.10",

--- a/blotztask-mobile/src/feature/ai-task-generate/services/ai-task-generator-signalr-service.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/services/ai-task-generator-signalr-service.ts
@@ -9,17 +9,19 @@ const SIGNALR_HUBS_CHAT = `${config.API_BASE_URL}/ai-task-generate-chathub`;
 export const signalRService = {
   createConnection: async () => {
     console.log("Attempting to create SignalR connection to:", SIGNALR_HUBS_CHAT);
-    const token = await getAuthToken();
-    if (!token) {
-      throw new Error("No valid Auth0 credentials available.");
-    }
 
     const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const url = `${SIGNALR_HUBS_CHAT}?timeZone=${encodeURIComponent(timeZone)}`;
 
     const connection = new signalR.HubConnectionBuilder()
       .withUrl(url, {
-        accessTokenFactory: () => token,
+        accessTokenFactory: async () => {
+          const token = await getAuthToken();
+          if (!token) {
+            throw new Error("No valid Auth0 credentials available.");
+          }
+          return token;
+        },
       })
       .withAutomaticReconnect()
       .build();

--- a/blotztask-mobile/src/feature/ai-task-generate/services/ai-task-generator-signalr-service.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/services/ai-task-generator-signalr-service.ts
@@ -1,6 +1,5 @@
 import * as signalR from "@microsoft/signalr";
-import * as SecureStore from "expo-secure-store";
-import { AUTH_TOKEN_KEY } from "@/shared/constants/token-key";
+import { getAuthToken } from "@/shared/services/api/token-manager";
 
 const config = {
   API_BASE_URL: process.env.EXPO_PUBLIC_URL,
@@ -10,10 +9,9 @@ const SIGNALR_HUBS_CHAT = `${config.API_BASE_URL}/ai-task-generate-chathub`;
 export const signalRService = {
   createConnection: async () => {
     console.log("Attempting to create SignalR connection to:", SIGNALR_HUBS_CHAT);
-    const token = await SecureStore.getItemAsync(AUTH_TOKEN_KEY);
-    // TODO: Add error handling
+    const token = await getAuthToken();
     if (!token) {
-      throw new Error("No token found in SecureStore.");
+      throw new Error("No valid Auth0 credentials available.");
     }
 
     const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/blotztask-mobile/src/feature/auth/components/get-started-button.tsx
+++ b/blotztask-mobile/src/feature/auth/components/get-started-button.tsx
@@ -33,9 +33,6 @@ export default function GetStartedButton() {
         return;
       }
 
-      // No manual token storage: `authorize()` already saved credentials to the
-      // Auth0 SDK credentials manager, which is the single source of truth.
-
       try {
         const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
         await updateUserProfile({ timezone });

--- a/blotztask-mobile/src/feature/auth/components/get-started-button.tsx
+++ b/blotztask-mobile/src/feature/auth/components/get-started-button.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { useAuth0 } from "react-native-auth0";
 import { useRouter } from "expo-router";
-import * as SecureStore from "expo-secure-store";
-import { AUTH_TOKEN_KEY, REFRESH_TOKEN_KEY } from "@/shared/constants/token-key";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "@/shared/hooks/useAuth";
 import { updateUserProfile } from "@/shared/services/user-service";
@@ -35,8 +33,8 @@ export default function GetStartedButton() {
         return;
       }
 
-      await SecureStore.setItemAsync(AUTH_TOKEN_KEY, result.accessToken);
-      await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, result.refreshToken);
+      // No manual token storage: `authorize()` already saved credentials to the
+      // Auth0 SDK credentials manager, which is the single source of truth.
 
       try {
         const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/blotztask-mobile/src/shared/constants/token-key.ts
+++ b/blotztask-mobile/src/shared/constants/token-key.ts
@@ -1,2 +1,0 @@
-export const AUTH_TOKEN_KEY = "blotz_auth_token";
-export const REFRESH_TOKEN_KEY = "blotz_refresh_token";

--- a/blotztask-mobile/src/shared/hooks/useAuth.ts
+++ b/blotztask-mobile/src/shared/hooks/useAuth.ts
@@ -1,6 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import * as SecureStore from "expo-secure-store";
-import { AUTH_TOKEN_KEY } from "@/shared/constants/token-key";
+import { auth0 } from "@/shared/services/api/auth0-client";
 
 /**
  * Authentication state hook that provides a single source of truth for auth status.
@@ -25,8 +24,7 @@ const AUTH_QUERY_KEY = ["auth", "status"] as const;
 
 async function checkAuthStatus(): Promise<boolean> {
   try {
-    const token = await SecureStore.getItemAsync(AUTH_TOKEN_KEY);
-    return !!token;
+    return await auth0.credentialsManager.hasValidCredentials();
   } catch (error) {
     console.error("Error checking auth status:", error);
     return false;

--- a/blotztask-mobile/src/shared/hooks/useLogout.ts
+++ b/blotztask-mobile/src/shared/hooks/useLogout.ts
@@ -1,9 +1,7 @@
-import * as SecureStore from "expo-secure-store";
 import { useAuth0 } from "react-native-auth0";
 import { useAuth } from "./useAuth";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
-import { AUTH_TOKEN_KEY, REFRESH_TOKEN_KEY } from "../constants/token-key";
 import { analytics } from "@/shared/services/analytics";
 
 export function useLogout() {
@@ -18,10 +16,6 @@ export function useLogout() {
     qc.clear();
 
     try {
-      await Promise.allSettled([
-        SecureStore.deleteItemAsync(AUTH_TOKEN_KEY),
-        SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY),
-      ]);
       await clearCredentials();
       console.log("🎯 clear credentials successfully");
       await clearSession();

--- a/blotztask-mobile/src/shared/services/api/auth0-client.ts
+++ b/blotztask-mobile/src/shared/services/api/auth0-client.ts
@@ -1,0 +1,13 @@
+import Auth0 from "react-native-auth0";
+import { AUTH_CONFIG } from "./config";
+
+/**
+ * Single shared Auth0 client.
+ *
+ * Its native credentials manager is the ONE source of truth for tokens: it owns
+ * the refresh token and handles rotation internally. Do not persist tokens
+ * anywhere else (e.g. SecureStore) — a second copy rotates independently and,
+ * with refresh-token rotation enabled, Auth0's breach detection will revoke the
+ * whole session and force users to log in again.
+ */
+export const auth0 = new Auth0(AUTH_CONFIG);

--- a/blotztask-mobile/src/shared/services/api/error-handlers.ts
+++ b/blotztask-mobile/src/shared/services/api/error-handlers.ts
@@ -1,5 +1,5 @@
 import { AxiosError, AxiosInstance, InternalAxiosRequestConfig } from "axios";
-import { clearTokens, refreshToken } from "./token-manager";
+import { clearTokens, forceRefreshAuthToken } from "./token-manager";
 import { router } from "expo-router";
 import { queryClient } from "@/shared/util/queryClient";
 import { AUTH_QUERY_KEY } from "@/shared/hooks/useAuth";
@@ -12,12 +12,14 @@ export function handleAuthError(
   // 401 which we attempt to refresh
   if (error.response?.status === 401 && !originalRequest._retry) {
     originalRequest._retry = true;
-    return refreshToken()
+    return forceRefreshAuthToken()
       .then((newToken) => {
+        if (!newToken) {
+          throw new Error("Unable to refresh Auth0 credentials");
+        }
         if (originalRequest.headers) {
           originalRequest.headers.Authorization = `Bearer ${newToken}`;
         }
-        console.log("get new tokens");
         return api(originalRequest);
       })
       .catch(() => {

--- a/blotztask-mobile/src/shared/services/api/token-manager.ts
+++ b/blotztask-mobile/src/shared/services/api/token-manager.ts
@@ -1,60 +1,42 @@
-import * as SecureStore from "expo-secure-store";
-import Auth0 from "react-native-auth0";
-import { AUTH_TOKEN_KEY, REFRESH_TOKEN_KEY } from "@/shared/constants/token-key";
-import { AUTH_CONFIG } from "./config";
+import { auth0 } from "./auth0-client";
 
-const auth0 = new Auth0(AUTH_CONFIG);
-
+/**
+ * Returns a valid access token, transparently refreshing it via the Auth0 SDK
+ * when the cached one is expired. The SDK owns the refresh token and handles
+ * rotation, so this is the single source of truth for tokens.
+ */
 export async function getAuthToken(): Promise<string | null> {
-  return await SecureStore.getItemAsync(AUTH_TOKEN_KEY);
+  try {
+    const credentials = await auth0.credentialsManager.getCredentials();
+    return credentials.accessToken;
+  } catch {
+    // No stored credentials, or the session was revoked/expired.
+    return null;
+  }
 }
 
-export async function setAuthToken(token: string): Promise<void> {
-  await SecureStore.setItemAsync(AUTH_TOKEN_KEY, token);
-}
-
-export async function getRefreshToken(): Promise<string | null> {
-  return await SecureStore.getItemAsync(REFRESH_TOKEN_KEY);
+/**
+ * Forces a refresh that bypasses the cached access token. Used to retry once
+ * after a 401 in case the access token was stale.
+ */
+export async function forceRefreshAuthToken(): Promise<string | null> {
+  try {
+    const credentials = await auth0.credentialsManager.getCredentials(
+      undefined,
+      0,
+      undefined,
+      true, // forceRefresh
+    );
+    return credentials.accessToken;
+  } catch {
+    return null;
+  }
 }
 
 export async function clearTokens(): Promise<void> {
-  await SecureStore.deleteItemAsync(AUTH_TOKEN_KEY);
-  await SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY);
-}
-
-let refreshTokenPromise: Promise<string> | null = null;
-
-export async function refreshToken(): Promise<string> {
-  if (refreshTokenPromise) {
-    console.log("wait for ongoing refresh token");
-    return refreshTokenPromise;
-  }
-
-  refreshTokenPromise = (async () => {
-    console.log("starts refresh token!");
-
-    const refreshTokenValue = await getRefreshToken();
-    if (!refreshTokenValue) {
-      throw new Error("No refresh token available");
-    }
-
-    const credentials = await auth0.auth.refreshToken({
-      refreshToken: refreshTokenValue,
-    });
-
-    console.log("get new tokens");
-
-    await setAuthToken(credentials.accessToken);
-    if (credentials.refreshToken) {
-      await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, credentials.refreshToken);
-    }
-
-    return credentials.accessToken;
-  })();
-
   try {
-    return await refreshTokenPromise;
-  } finally {
-    refreshTokenPromise = null;
+    await auth0.credentialsManager.clearCredentials();
+  } catch {
+    // Nothing stored — ignore.
   }
 }

--- a/blotztask-mobile/src/shared/services/api/token-manager.ts
+++ b/blotztask-mobile/src/shared/services/api/token-manager.ts
@@ -1,42 +1,37 @@
 import { auth0 } from "./auth0-client";
 
-/**
- * Returns a valid access token, transparently refreshing it via the Auth0 SDK
- * when the cached one is expired. The SDK owns the refresh token and handles
- * rotation, so this is the single source of truth for tokens.
- */
+// Returns a valid access token; the SDK refreshes/rotates it when expired.
 export async function getAuthToken(): Promise<string | null> {
   try {
-    const credentials = await auth0.credentialsManager.getCredentials();
-    return credentials.accessToken;
+    const { accessToken } = await auth0.credentialsManager.getCredentials();
+    return accessToken;
   } catch {
-    // No stored credentials, or the session was revoked/expired.
     return null;
   }
 }
 
-/**
- * Forces a refresh that bypasses the cached access token. Used to retry once
- * after a 401 in case the access token was stale.
- */
-export async function forceRefreshAuthToken(): Promise<string | null> {
+async function refresh(): Promise<string | null> {
   try {
-    const credentials = await auth0.credentialsManager.getCredentials(
-      undefined,
-      0,
-      undefined,
-      true, // forceRefresh
-    );
-    return credentials.accessToken;
+    const { accessToken } = await auth0.credentialsManager.getCredentials(undefined, 0, undefined, true);
+    return accessToken;
   } catch {
     return null;
   }
+}
+
+// Force a refresh after a 401, sharing one request across concurrent callers
+// so parallel 401s can't trigger multiple token rotations.
+let inFlightRefresh: Promise<string | null> | null = null;
+
+export function forceRefreshAuthToken(): Promise<string | null> {
+  if (!inFlightRefresh) {
+    inFlightRefresh = refresh().finally(() => {
+      inFlightRefresh = null;
+    });
+  }
+  return inFlightRefresh;
 }
 
 export async function clearTokens(): Promise<void> {
-  try {
-    await auth0.credentialsManager.clearCredentials();
-  } catch {
-    // Nothing stored — ignore.
-  }
+  await auth0.credentialsManager.clearCredentials();
 }


### PR DESCRIPTION
## Summary

Made the Auth0 SDK credentials manager the single source of truth for tokens and removed the duplicate expo-secure-store copy. The SDK now owns the refresh token and handles rotation internally, so the two stores can't collide anymore.


## Release note

Users stay logged in and no longer get randomly signed out. Tokens refresh silently in the background; the only sign-in needed is the normal one when a session genuinely reaches its expiry which is 90 days.


**Status:**

- [x] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce
