### PR TITLE
group date format in one file

### DIFF
--- a/blotztask-mobile/src/feature/badge/components/badge-achievement-modal.tsx
+++ b/blotztask-mobile/src/feature/badge/components/badge-achievement-modal.tsx
@@ -1,6 +1,6 @@
 import { BadgeNotificationDTO } from "@/feature/badge/models/badge-notification-dto";
-import { formatBadgeDate } from "@/feature/badge/utils/format-badge-date";
 import { GradientColor } from "@/shared/components/gradient-color";
+import { formatLocalizedDate } from "@/shared/util/localized-date-format";
 import MaterialIcons from "@react-native-vector-icons/material-icons/static";
 import { Image } from "expo-image";
 import { useTranslation } from "react-i18next";
@@ -12,7 +12,7 @@ interface BadgeAchievementModalProps {
 }
 
 export function BadgeAchievementModal({ badge, onDismiss }: BadgeAchievementModalProps) {
-  const { t } = useTranslation("badge");
+  const { t, i18n } = useTranslation("badge");
 
   if (!badge) return null;
 
@@ -51,7 +51,9 @@ export function BadgeAchievementModal({ badge, onDismiss }: BadgeAchievementModa
           </Text>
 
           <Text className="text-white text-xl font-baloo mt-4">
-            {t("obtainedOn", { date: formatBadgeDate(badge.obtainedAt) })}
+            {t("obtainedOn", {
+              date: formatLocalizedDate(badge.obtainedAt, "longDate", i18n.language),
+            })}
           </Text>
         </View>
       </View>

--- a/blotztask-mobile/src/feature/badge/components/badge-achievement-modal.tsx
+++ b/blotztask-mobile/src/feature/badge/components/badge-achievement-modal.tsx
@@ -12,7 +12,7 @@ interface BadgeAchievementModalProps {
 }
 
 export function BadgeAchievementModal({ badge, onDismiss }: BadgeAchievementModalProps) {
-  const { t, i18n } = useTranslation("badge");
+  const { t } = useTranslation("badge");
 
   if (!badge) return null;
 
@@ -52,7 +52,7 @@ export function BadgeAchievementModal({ badge, onDismiss }: BadgeAchievementModa
 
           <Text className="text-white text-xl font-baloo mt-4">
             {t("obtainedOn", {
-              date: formatLocalizedDate(badge.obtainedAt, "longDate", i18n.language),
+              date: formatLocalizedDate(badge.obtainedAt, "fullMonthDayYear"),
             })}
           </Text>
         </View>

--- a/blotztask-mobile/src/feature/badge/utils/format-badge-date.ts
+++ b/blotztask-mobile/src/feature/badge/utils/format-badge-date.ts
@@ -1,8 +1,0 @@
-import i18n from "@/i18n";
-import { format } from "date-fns";
-
-export function formatBadgeDate(date: Date): string {
-  const isChinese = i18n.language === "zh";
-  const pattern = isChinese ? "yyyy年M月d日" : "MMMM d, yyyy";
-  return format(date, pattern);
-}

--- a/blotztask-mobile/src/feature/calendar/util/date-formatter.tsx
+++ b/blotztask-mobile/src/feature/calendar/util/date-formatter.tsx
@@ -57,7 +57,7 @@ export const formatCalendarDate = (
 export const renderCalendarHeader = (date?: unknown) => {
   if (!date) return null;
   const dateObj = date instanceof Date ? date : new Date(date.toString());
-  const dateText = formatLocalizedDate(dateObj, "monthYear", i18n.language);
+  const dateText = formatLocalizedDate(dateObj, "monthYear");
   return (
     <Text
       style={{
@@ -69,15 +69,4 @@ export const renderCalendarHeader = (date?: unknown) => {
       {dateText}
     </Text>
   );
-};
-
-/**
- * Formats a date for the Monthly Calendar BottomSheet display
- * @param date - Date object or date string
- * @returns Formatted date string (English: Mon, 15 Apr 2026 | Chinese: 4月15日)
- */
-export const formatBottomSheetDate = (date?: unknown) => {
-  if (!date) return "";
-  const dateObj = date instanceof Date ? date : new Date(date.toString());
-  return formatLocalizedDate(dateObj, "dateWithWeekday", i18n.language);
 };

--- a/blotztask-mobile/src/feature/calendar/util/date-formatter.tsx
+++ b/blotztask-mobile/src/feature/calendar/util/date-formatter.tsx
@@ -1,8 +1,9 @@
 import { isSameDay, format } from "date-fns";
-import { enUS, zhCN } from "date-fns/locale";
+import { enUS } from "date-fns/locale";
 import i18n from "@/i18n";
 import { Text } from "react-native";
 import { Language, UserPreferencesDTO } from "@/shared/models/user-preferences-dto";
+import { formatLocalizedDate } from "@/shared/util/localized-date-format";
 
 /**
  * Formats a date string for calendar display
@@ -56,9 +57,7 @@ export const formatCalendarDate = (
 export const renderCalendarHeader = (date?: unknown) => {
   if (!date) return null;
   const dateObj = date instanceof Date ? date : new Date(date.toString());
-  const isChinese = i18n.language === "zh";
-  const locale = isChinese ? zhCN : enUS;
-  const dateText = format(dateObj, "MMMM yyyy", { locale });
+  const dateText = formatLocalizedDate(dateObj, "monthYear", i18n.language);
   return (
     <Text
       style={{
@@ -80,11 +79,5 @@ export const renderCalendarHeader = (date?: unknown) => {
 export const formatBottomSheetDate = (date?: unknown) => {
   if (!date) return "";
   const dateObj = date instanceof Date ? date : new Date(date.toString());
-  const isChinese = i18n.language === "zh";
-
-  if (isChinese) {
-    return format(dateObj, "yyyy年M月d日 EEE", { locale: zhCN });
-  }
-
-  return format(dateObj, "E, d MMM yyyy", { locale: enUS });
+  return formatLocalizedDate(dateObj, "dateWithWeekday", i18n.language);
 };

--- a/blotztask-mobile/src/feature/monthly-calendar/screens/monthly-calendar-screen.tsx
+++ b/blotztask-mobile/src/feature/monthly-calendar/screens/monthly-calendar-screen.tsx
@@ -11,9 +11,9 @@ import { MonthlyDay, MonthlyDayProps } from "../components/monthly-day";
 import { SelectedDayDetailPanel } from "../components/day-detail-panel";
 import { TaskThumbnailDTO } from "../models/monthly-task-indicator-dto";
 import BottomSheet from "@gorhom/bottom-sheet";
-import { formatBottomSheetDate } from "@/feature/calendar/util/date-formatter";
 import i18n from "@/i18n";
 import { ReturnButton } from "@/shared/components/return-button";
+import { formatLocalizedDate } from "@/shared/util/localized-date-format";
 
 const SNAP_L1 = "10%";
 const SNAP_L2 = "50%";
@@ -128,7 +128,7 @@ export default function MonthlyCalendarScreen() {
             />
             <View className="w-full items-start">
               <Text className="text-base font-baloo text-secondary">
-                {formatBottomSheetDate(selectedDay)}
+                {formatLocalizedDate(selectedDay, "weekdayDayMonthYear")}
               </Text>
             </View>
           </View>

--- a/blotztask-mobile/src/feature/review/screens/review-screen.tsx
+++ b/blotztask-mobile/src/feature/review/screens/review-screen.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { addMonths, format, isAfter, isSameMonth, startOfMonth, subMonths } from "date-fns";
 import { useUserProfile } from "@/shared/hooks/useUserProfile";
+import { formatLocalizedDate } from "@/shared/util/localized-date-format";
 import { LetterCardContent } from "../components/letter-card-content";
 import { LetterHeader } from "../components/letter-header";
 import { PeriodSelector } from "../components/period-selector";
@@ -16,7 +17,6 @@ import { WeeklyReviewView } from "../components/weekly-review-view";
 import { useReview } from "../hooks/useReviewReport";
 import { useReviewShare } from "../hooks/useReviewShare";
 import { ReviewPeriodType } from "../models/review-dto";
-import { formatMonth } from "../utils/month-utils";
 
 export default function ReviewScreen() {
   // — Hooks ——————————————————————————————————————————————————————
@@ -60,7 +60,7 @@ export default function ReviewScreen() {
   const isAtLatestMonth = isSameMonth(selectedMonth, latestReviewableMonth);
   const isAtEarliestMonth =
     earliestReviewableMonth !== null && isSameMonth(selectedMonth, earliestReviewableMonth);
-  const displayMonth = formatMonth(selectedMonth, i18n.language);
+  const displayMonth = formatLocalizedDate(selectedMonth, "yearMonth", i18n.language);
   const recipientName = userProfile?.displayName ?? t("review.defaultRecipient");
   const showShareButton = isMonthlyTab
     ? report !== null && !hasNoReviewableMonth

--- a/blotztask-mobile/src/feature/review/screens/review-screen.tsx
+++ b/blotztask-mobile/src/feature/review/screens/review-screen.tsx
@@ -21,7 +21,7 @@ import { ReviewPeriodType } from "../models/review-dto";
 export default function ReviewScreen() {
   // — Hooks ——————————————————————————————————————————————————————
   const router = useRouter();
-  const { t, i18n } = useTranslation("settings");
+  const { t } = useTranslation("settings");
   const { userProfile } = useUserProfile();
   // Default to Weekly — it produces fresh content more often than Monthly.
   const [activeTab, setActiveTab] = useState<ReviewTab>(ReviewPeriodType.Weekly);
@@ -60,7 +60,7 @@ export default function ReviewScreen() {
   const isAtLatestMonth = isSameMonth(selectedMonth, latestReviewableMonth);
   const isAtEarliestMonth =
     earliestReviewableMonth !== null && isSameMonth(selectedMonth, earliestReviewableMonth);
-  const displayMonth = formatLocalizedDate(selectedMonth, "yearMonth", i18n.language);
+  const displayMonth = formatLocalizedDate(selectedMonth, "yearMonth");
   const recipientName = userProfile?.displayName ?? t("review.defaultRecipient");
   const showShareButton = isMonthlyTab
     ? report !== null && !hasNoReviewableMonth

--- a/blotztask-mobile/src/feature/review/utils/month-utils.ts
+++ b/blotztask-mobile/src/feature/review/utils/month-utils.ts
@@ -1,9 +1,0 @@
-import { format } from "date-fns";
-import { enUS, zhCN } from "date-fns/locale";
-
-export function formatMonth(date: Date, lang: string): string {
-  const isZh = lang.toLowerCase().startsWith("zh");
-  return format(date, isZh ? "yyyy年M月" : "MMMM yyyy", {
-    locale: isZh ? zhCN : enUS,
-  });
-}

--- a/blotztask-mobile/src/feature/task-add-edit/components/deadline-section.tsx
+++ b/blotztask-mobile/src/feature/task-add-edit/components/deadline-section.tsx
@@ -4,11 +4,11 @@ import { View, Text, Pressable } from "react-native";
 import Toast from "react-native-toast-message";
 import { Control, UseFormGetValues, useController } from "react-hook-form";
 import { format } from "date-fns";
-import { zhCN, enUS } from "date-fns/locale";
 import { useTranslation } from "react-i18next";
 import TaskFormField, { hasDeadlineWarning } from "../models/task-form-schema";
 import Animated from "react-native-reanimated";
 import { MotionAnimations } from "@/shared/constants/animations/motion";
+import { formatLocalizedDate } from "@/shared/util/localized-date-format";
 import { ToggleSwitch } from "../../settings/components/toggle-switch";
 import { SingleDateCalendar } from "./single-date-calendar";
 import TimePicker from "./time-picker";
@@ -23,9 +23,6 @@ interface DeadlineSectionProps {
 
 export const DeadlineSection = ({ control, getValues, isActiveTab }: DeadlineSectionProps) => {
   const { t, i18n } = useTranslation("tasks");
-  const isChinese = i18n.language === "zh";
-  const locale = isChinese ? zhCN : enUS;
-  const dateFormat = isChinese ? "yyyy年M月d日" : "MMM d, yyyy";
 
   const [activeSelector, setActiveSelector] = useState<"deadlineDate" | "deadlineTime" | null>(
     null,
@@ -75,7 +72,7 @@ export const DeadlineSection = ({ control, getValues, isActiveTab }: DeadlineSec
   }, [deadlineDate, deadlineTime]);
 
   const deadlineDateDisplayText = deadlineDate
-    ? format(deadlineDate, dateFormat, { locale })
+    ? formatLocalizedDate(deadlineDate, "formDate", i18n.language)
     : t("form.selectDate");
   const deadlineTimeDisplayText = deadlineTime
     ? format(deadlineTime, "hh:mm a")

--- a/blotztask-mobile/src/feature/task-add-edit/components/deadline-section.tsx
+++ b/blotztask-mobile/src/feature/task-add-edit/components/deadline-section.tsx
@@ -22,7 +22,7 @@ interface DeadlineSectionProps {
 }
 
 export const DeadlineSection = ({ control, getValues, isActiveTab }: DeadlineSectionProps) => {
-  const { t, i18n } = useTranslation("tasks");
+  const { t } = useTranslation("tasks");
 
   const [activeSelector, setActiveSelector] = useState<"deadlineDate" | "deadlineTime" | null>(
     null,
@@ -72,7 +72,7 @@ export const DeadlineSection = ({ control, getValues, isActiveTab }: DeadlineSec
   }, [deadlineDate, deadlineTime]);
 
   const deadlineDateDisplayText = deadlineDate
-    ? formatLocalizedDate(deadlineDate, "formDate", i18n.language)
+    ? formatLocalizedDate(deadlineDate, "abbrevMonthDayYear")
     : t("form.selectDate");
   const deadlineTimeDisplayText = deadlineTime
     ? format(deadlineTime, "hh:mm a")

--- a/blotztask-mobile/src/feature/task-add-edit/components/event-tab.tsx
+++ b/blotztask-mobile/src/feature/task-add-edit/components/event-tab.tsx
@@ -10,7 +10,6 @@ import {
   isBefore,
   isEqual,
 } from "date-fns";
-import { zhCN, enUS } from "date-fns/locale";
 import { useController, useFormContext } from "react-hook-form";
 import { TimeFormValues } from "../models/task-form-schema";
 import TimePicker from "./time-picker";
@@ -18,6 +17,7 @@ import DoubleDatesCalendar from "./double-dates-calendar";
 import { useTranslation } from "react-i18next";
 import Animated from "react-native-reanimated";
 import { MotionAnimations } from "@/shared/constants/animations/motion";
+import { formatLocalizedDate } from "@/shared/util/localized-date-format";
 import { combineDateTime } from "../util/combine-date-time";
 
 export const EventTab = () => {
@@ -33,9 +33,6 @@ export const EventTab = () => {
     }
   };
   const { t, i18n } = useTranslation("tasks");
-  const isChinese = i18n.language === "zh";
-  const locale = isChinese ? zhCN : enUS;
-  const dateFormat = isChinese ? "yyyy年M月d日" : "MMM d, yyyy";
   const [activeSelector, setActiveSelector] = useState<
     "startDate" | "startTime" | "endDate" | "endTime" | null
   >(null);
@@ -91,7 +88,7 @@ export const EventTab = () => {
             >
               <Text className="text-xl font-balooThin text-secondary">
                 {startDateValue
-                  ? format(startDateValue, dateFormat, { locale })
+                  ? formatLocalizedDate(startDateValue, "formDate", i18n.language)
                   : t("form.selectDate")}
               </Text>
             </Pressable>
@@ -154,7 +151,9 @@ export const EventTab = () => {
                       : "text-secondary"
                 }`}
               >
-                {endDateValue ? format(endDateValue, dateFormat, { locale }) : t("form.selectDate")}
+                {endDateValue
+                  ? formatLocalizedDate(endDateValue, "formDate", i18n.language)
+                  : t("form.selectDate")}
               </Text>
             </Pressable>
 

--- a/blotztask-mobile/src/feature/task-add-edit/components/event-tab.tsx
+++ b/blotztask-mobile/src/feature/task-add-edit/components/event-tab.tsx
@@ -32,7 +32,7 @@ export const EventTab = () => {
       trigger("endTime");
     }
   };
-  const { t, i18n } = useTranslation("tasks");
+  const { t } = useTranslation("tasks");
   const [activeSelector, setActiveSelector] = useState<
     "startDate" | "startTime" | "endDate" | "endTime" | null
   >(null);
@@ -88,7 +88,7 @@ export const EventTab = () => {
             >
               <Text className="text-xl font-balooThin text-secondary">
                 {startDateValue
-                  ? formatLocalizedDate(startDateValue, "formDate", i18n.language)
+                  ? formatLocalizedDate(startDateValue, "abbrevMonthDayYear")
                   : t("form.selectDate")}
               </Text>
             </Pressable>
@@ -152,7 +152,7 @@ export const EventTab = () => {
                 }`}
               >
                 {endDateValue
-                  ? formatLocalizedDate(endDateValue, "formDate", i18n.language)
+                  ? formatLocalizedDate(endDateValue, "abbrevMonthDayYear")
                   : t("form.selectDate")}
               </Text>
             </Pressable>

--- a/blotztask-mobile/src/feature/task-add-edit/components/recurrence-end-section.tsx
+++ b/blotztask-mobile/src/feature/task-add-edit/components/recurrence-end-section.tsx
@@ -2,11 +2,11 @@ import React, { useEffect, useState } from "react";
 import { Pressable, Text } from "react-native";
 import { Control, useController } from "react-hook-form";
 import { format } from "date-fns";
-import { enUS, zhCN } from "date-fns/locale";
 import { useTranslation } from "react-i18next";
 import Animated from "react-native-reanimated";
 import { AnimatedDropdown, DropdownOption } from "@/shared/components/animated-dropdown";
 import { MotionAnimations } from "@/shared/constants/animations/motion";
+import { formatLocalizedDate } from "@/shared/util/localized-date-format";
 import { TaskFormField } from "@/feature/task-add-edit/models/task-form-schema";
 import { SingleDateCalendar } from "./single-date-calendar";
 
@@ -16,9 +16,6 @@ type RecurrenceEndSectionProps = {
 
 export const RecurrenceEndSection = ({ control }: RecurrenceEndSectionProps) => {
   const { t, i18n } = useTranslation("tasks");
-  const isChinese = i18n.language === "zh";
-  const locale = isChinese ? zhCN : enUS;
-  const dateFormat = isChinese ? "yyyy年M月d日" : "MMM d, yyyy";
   const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
 
   const {
@@ -67,7 +64,7 @@ export const RecurrenceEndSection = ({ control }: RecurrenceEndSectionProps) => 
   ];
 
   const recurrenceEndDateDisplayText = recurrenceEndDate
-    ? format(recurrenceEndDate, dateFormat, { locale })
+    ? formatLocalizedDate(recurrenceEndDate, "formDate", i18n.language)
     : t("form.selectDate");
 
   return (

--- a/blotztask-mobile/src/feature/task-add-edit/components/recurrence-end-section.tsx
+++ b/blotztask-mobile/src/feature/task-add-edit/components/recurrence-end-section.tsx
@@ -15,7 +15,7 @@ type RecurrenceEndSectionProps = {
 };
 
 export const RecurrenceEndSection = ({ control }: RecurrenceEndSectionProps) => {
-  const { t, i18n } = useTranslation("tasks");
+  const { t } = useTranslation("tasks");
   const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
 
   const {
@@ -64,7 +64,7 @@ export const RecurrenceEndSection = ({ control }: RecurrenceEndSectionProps) => 
   ];
 
   const recurrenceEndDateDisplayText = recurrenceEndDate
-    ? formatLocalizedDate(recurrenceEndDate, "formDate", i18n.language)
+    ? formatLocalizedDate(recurrenceEndDate, "abbrevMonthDayYear")
     : t("form.selectDate");
 
   return (

--- a/blotztask-mobile/src/feature/task-add-edit/components/reminder-tab.tsx
+++ b/blotztask-mobile/src/feature/task-add-edit/components/reminder-tab.tsx
@@ -28,9 +28,9 @@ export const ReminderTab = () => {
     name: "startTime",
   });
 
-  const { t, i18n } = useTranslation("tasks");
+  const { t } = useTranslation("tasks");
   const dateDisplayText = startDate
-    ? formatLocalizedDate(startDate, "formDate", i18n.language)
+    ? formatLocalizedDate(startDate, "abbrevMonthDayYear")
     : t("form.selectDate");
   const timeDisplayText = startTime ? format(startTime, "hh:mm a") : t("form.selectTime");
 

--- a/blotztask-mobile/src/feature/task-add-edit/components/reminder-tab.tsx
+++ b/blotztask-mobile/src/feature/task-add-edit/components/reminder-tab.tsx
@@ -1,13 +1,13 @@
 import { useController, useFormContext } from "react-hook-form";
 import { View, Text, Pressable } from "react-native";
 import { format } from "date-fns";
-import { zhCN, enUS } from "date-fns/locale";
 import { useState } from "react";
 import TimePicker from "./time-picker";
 import { SingleDateCalendar } from "./single-date-calendar";
 import { useTranslation } from "react-i18next";
 import Animated from "react-native-reanimated";
 import { MotionAnimations } from "@/shared/constants/animations/motion";
+import { formatLocalizedDate } from "@/shared/util/localized-date-format";
 import { TimeFormValues } from "../models/task-form-schema";
 
 export const ReminderTab = () => {
@@ -29,11 +29,8 @@ export const ReminderTab = () => {
   });
 
   const { t, i18n } = useTranslation("tasks");
-  const isChinese = i18n.language === "zh";
-  const locale = isChinese ? zhCN : enUS;
-  const dateFormat = isChinese ? "yyyy年M月d日" : "MMM d, yyyy";
   const dateDisplayText = startDate
-    ? format(startDate, dateFormat, { locale })
+    ? formatLocalizedDate(startDate, "formDate", i18n.language)
     : t("form.selectDate");
   const timeDisplayText = startTime ? format(startTime, "hh:mm a") : t("form.selectTime");
 

--- a/blotztask-mobile/src/shared/util/localized-date-format.ts
+++ b/blotztask-mobile/src/shared/util/localized-date-format.ts
@@ -1,0 +1,39 @@
+import { format } from "date-fns";
+import { enUS, zhCN } from "date-fns/locale";
+
+const DATE_FORMAT_PATTERNS = {
+  formDate: {
+    en: "MMM d, yyyy",
+    zh: "yyyy年M月d日",
+  },
+  longDate: {
+    en: "MMMM d, yyyy",
+    zh: "yyyy年M月d日",
+  },
+  dateWithWeekday: {
+    en: "E, d MMM yyyy",
+    zh: "yyyy年M月d日 EEE",
+  },
+  monthYear: {
+    en: "MMMM yyyy",
+    zh: "MMMM yyyy",
+  },
+  yearMonth: {
+    en: "MMMM yyyy",
+    zh: "yyyy年M月",
+  },
+};
+
+type LocalizedDateFormatPreset = keyof typeof DATE_FORMAT_PATTERNS;
+
+export const formatLocalizedDate = (
+  date: Date,
+  dateFormat: LocalizedDateFormatPreset,
+  language: string,
+) => {
+  const userLanguage = language.toLowerCase().startsWith("zh") ? "zh" : "en";
+
+  return format(date, DATE_FORMAT_PATTERNS[dateFormat][userLanguage], {
+    locale: userLanguage === "zh" ? zhCN : enUS,
+  });
+};

--- a/blotztask-mobile/src/shared/util/localized-date-format.ts
+++ b/blotztask-mobile/src/shared/util/localized-date-format.ts
@@ -1,16 +1,17 @@
 import { format } from "date-fns";
 import { enUS, zhCN } from "date-fns/locale";
+import i18n from "@/i18n";
 
 const DATE_FORMAT_PATTERNS = {
-  formDate: {
+  abbrevMonthDayYear: {
     en: "MMM d, yyyy",
     zh: "yyyy年M月d日",
   },
-  longDate: {
+  fullMonthDayYear: {
     en: "MMMM d, yyyy",
     zh: "yyyy年M月d日",
   },
-  dateWithWeekday: {
+  weekdayDayMonthYear: {
     en: "E, d MMM yyyy",
     zh: "yyyy年M月d日 EEE",
   },
@@ -26,12 +27,8 @@ const DATE_FORMAT_PATTERNS = {
 
 type LocalizedDateFormatPreset = keyof typeof DATE_FORMAT_PATTERNS;
 
-export const formatLocalizedDate = (
-  date: Date,
-  dateFormat: LocalizedDateFormatPreset,
-  language: string,
-) => {
-  const userLanguage = language.toLowerCase().startsWith("zh") ? "zh" : "en";
+export const formatLocalizedDate = (date: Date, dateFormat: LocalizedDateFormatPreset) => {
+  const userLanguage = i18n.language.toLowerCase().startsWith("zh") ? "zh" : "en";
 
   return format(date, DATE_FORMAT_PATTERNS[dateFormat][userLanguage], {
     locale: userLanguage === "zh" ? zhCN : enUS,


### PR DESCRIPTION
## Summary

Centralized localized date display formatting in a shared mobile utility and replaced duplicated date-fns locale/pattern logic across task add/edit, calendar, badge, and review screens.

This is a refactor only; existing English and Chinese date display formats are intended to stay the same.


## Release note

> none

**Status:**

- [ ] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [x] Internal only (refactor / infra / tests / CI / deps) — don't announce
