### PR TITLE
Enhance note extraction prompts and update task generation descriptio…

### DIFF
--- a/blotztask-api/Modules/ChatTaskGenerator/Constants/AiTaskGeneratorPrompts.cs
+++ b/blotztask-api/Modules/ChatTaskGenerator/Constants/AiTaskGeneratorPrompts.cs
@@ -5,14 +5,32 @@ public static class AiTaskGeneratorPrompts
     public static string GetSystemMessage(string preferredLanguage, DateTime userLocalTime)
     {
         return $"""
-                Respond in {preferredLanguage}. The user's current local time is {userLocalTime:yyyy-MM-dd HH:mm}. 
+                Respond in {preferredLanguage}. The user's current local time is {userLocalTime:yyyy-MM-dd HH:mm}.
                 You maintain a running list of tasks and notes across this conversation.
+                Your ONLY job is to call tools — never reply with text alone.
 
-                Only create a task or note when the user expresses a clear intention.
-                Use CreateTask if the item has any date or time context, even if vague.
-                Use CreateNote if the item has no date or time reference at all — do not skip it.
+                Map every user intent to a tool call:
+                - New item with a time anchor → CreateTask (or CreateTasks for multiple)
+                - New item with no time anchor → CreateNote (or CreateNotes for multiple)
+                - Correction or adjustment to an existing item → UpdateTask or UpdateNote
+                - User cancels or removes something → RemoveTask or RemoveNote
 
-                When no specific time is given for a task, pick a sensible time based on the activity context.
+                Evaluate each item independently. A single message may produce both tasks and notes.
+                When no specific time is stated for a task, pick a sensible one based on context.
+
+                Examples:
+                "Remind me to drink water in 10 minutes, buy groceries at 5pm, and I want to learn guitar"
+                → CreateTasks(["Drink water", "Buy groceries"], ..., [now+10min, 17:00], ...)
+                → CreateNote("Learn guitar")
+
+                "Change the gym session to 7am"
+                → UpdateTask("Gym session", ..., 07:00, ...)
+
+                "Actually forget the grocery run"
+                → RemoveTask("Buy groceries")
+
+                "Update my note about guitar — make it learn piano instead"
+                → UpdateNote("Learn guitar", "Learn piano")
                 """;
     }
 }

--- a/blotztask-api/Modules/ChatTaskGenerator/DevTools/quality-check-cases.json
+++ b/blotztask-api/Modules/ChatTaskGenerator/DevTools/quality-check-cases.json
@@ -46,5 +46,33 @@
         "label": "Work"
       }
     ]
+  },
+  {
+    "id": "pure-note-intention",
+    "input": "I want to learn guitar",
+    "expectedTaskCount": 0,
+    "expectedNoteCount": 1,
+    "expectations": []
+  },
+  {
+    "id": "mixed-task-and-note",
+    "input": "Coffee with Sarah tomorrow at 9am and I should read more books",
+    "expectedTaskCount": 1,
+    "expectedNoteCount": 1,
+    "expectations": [
+      {
+        "titleContains": ["coffee", "Sarah"],
+        "startTimeHour": 9,
+        "startDateOffset": 1,
+        "label": "Life"
+      }
+    ]
+  },
+  {
+    "id": "multiple-notes-no-tasks",
+    "input": "Remember to water the plants, buy sunglasses, and look into learning Spanish",
+    "expectedTaskCount": 0,
+    "expectedNoteCount": 3,
+    "expectations": []
   }
 ]

--- a/blotztask-api/Modules/ChatTaskGenerator/Functions/TaskGenerationTools.cs
+++ b/blotztask-api/Modules/ChatTaskGenerator/Functions/TaskGenerationTools.cs
@@ -65,7 +65,7 @@ public class TaskGenerationTools()
         return "Task added.";
     }
 
-    [Description("Add multiple notes at once. Prefer this over CreateNote when the user mentions more than one note.")]
+    [Description("Add multiple notes at once. Prefer this over CreateNote when the user mentions more than one timeless item.")]
     public async Task<string> CreateNotes(
         [Description("Array of note texts")] string[] texts)
     {
@@ -83,7 +83,7 @@ public class TaskGenerationTools()
         return $"{texts.Length} note(s) added.";
     }
 
-    [Description("Add a single note for an idea or something to remember. Use this when no date or time is mentioned.")]
+    [Description("Add a single note for an idea, intention, or reminder with no time anchor. Use this when scheduling the item would require inventing a time the user never mentioned — even vaguely.")]
     public async Task<string> CreateNote(
         [Description("Note content")] string text)
     {


### PR DESCRIPTION
## Summary

- Rewrite AI system prompt: remove the "clear intention" gate that let the AI skip tool calls, replace with an explicit extraction contract and CRUD examples covering create, update, and remove
- Tighten `CreateNote`/`CreateNotes` tool descriptions so the AI evaluates each item independently — a timeless item is no longer skipped just because a time-anchored item appeared in the same message
- Add 3 quality check cases targeting note extraction (`pure-note-intention`, `mixed-task-and-note`, `multiple-notes-no-tasks`) — all pass 6/6 after the fix

## Release note

> none

**Status:**

- [ ] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [x] Internal only (refactor / infra / tests / CI / deps) — don't announce