### PR TITLE
fix bug for pomodoro buttons not work in android

### DIFF
--- a/blotztask-mobile/src/feature/calendar/components/task-card-left-actions.tsx
+++ b/blotztask-mobile/src/feature/calendar/components/task-card-left-actions.tsx
@@ -1,6 +1,7 @@
 import Ionicons from "@react-native-vector-icons/ionicons/static";
 import MaterialCommunityIcons from "@react-native-vector-icons/material-design-icons/static";
-import { Pressable, Text, View } from "react-native";
+import { Text, View } from "react-native";
+import { Pressable } from "react-native-gesture-handler";
 import Animated, { SharedValue, useAnimatedStyle } from "react-native-reanimated";
 import { useTranslation } from "react-i18next";
 
@@ -28,40 +29,37 @@ export const TaskCardLeftActions = ({
   return (
     <Animated.View className="flex-row items-start justify-start gap-2 pr-4" style={animatedStyle}>
       {isPomodoroActiveTask ? (
-        <Pressable
-          onPress={onTogglePause}
-          className="h-full w-24 rounded-3xl bg-[#FFF0F0] border border-[#F567674D] items-center justify-center"
-        >
-          <View className="items-center gap-1.5">
-            <Ionicons name={isPaused ? "play-circle" : "pause-circle"} size={28} color="#F87171" />
-            <Text className="text-red-400 font-inter font-bold text-[13px]">
-              {isPaused ? "Resume" : "Pause"}
-            </Text>
+        <Pressable onPress={onTogglePause}>
+          <View className="h-20 w-24 rounded-3xl bg-[#FFF0F0] border border-[#F567674D] items-center justify-center">
+            <View className="items-center gap-1.5">
+              <Ionicons name={isPaused ? "play-circle" : "pause-circle"} size={28} color="#F87171" />
+              <Text className="text-red-400 font-inter font-bold text-[13px]">
+                {isPaused ? "Resume" : "Pause"}
+              </Text>
+            </View>
           </View>
         </Pressable>
       ) : (
         <>
-          <Pressable
-            onPress={onMode}
-            className="h-20 w-24 rounded-3xl bg-blue-50 border border-blue-300 items-center justify-center"
-          >
-            <View className="items-center gap-1">
-              <MaterialCommunityIcons name="cog" size={24} color="#53A8FF" />
-              <Text className="text-blue-400 font-inter font-semibold text-[13px]">
-                {t("taskCard.modes")}
-              </Text>
+          <Pressable onPress={onMode}>
+            <View className="h-20 w-24 rounded-3xl bg-blue-50 border border-blue-300 items-center justify-center">
+              <View className="items-center gap-1">
+                <MaterialCommunityIcons name="cog" size={24} color="#53A8FF" />
+                <Text className="text-blue-400 font-inter font-semibold text-[13px]">
+                  {t("taskCard.modes")}
+                </Text>
+              </View>
             </View>
           </Pressable>
 
-          <Pressable
-            onPress={onFocus}
-            className="h-20 w-24 rounded-3xl bg-orange-50 border border-orange-300 items-center justify-center"
-          >
-            <View className="items-center gap-1">
-              <MaterialCommunityIcons name="clock" size={24} color="#FFAA4A" />
-              <Text className="text-orange-400 font-inter font-semibold text-[13px]">
-                {t("taskCard.focus")}
-              </Text>
+          <Pressable onPress={onFocus}>
+            <View className="h-20 w-24 rounded-3xl bg-orange-50 border border-orange-300 items-center justify-center">
+              <View className="items-center gap-1">
+                <MaterialCommunityIcons name="clock" size={24} color="#FFAA4A" />
+                <Text className="text-orange-400 font-inter font-semibold text-[13px]">
+                  {t("taskCard.focus")}
+                </Text>
+              </View>
             </View>
           </Pressable>
         </>

--- a/blotztask-mobile/src/feature/calendar/components/task-card-left-actions.tsx
+++ b/blotztask-mobile/src/feature/calendar/components/task-card-left-actions.tsx
@@ -30,36 +30,30 @@ export const TaskCardLeftActions = ({
     <Animated.View className="flex-row items-start justify-start gap-2 pr-4" style={animatedStyle}>
       {isPomodoroActiveTask ? (
         <Pressable onPress={onTogglePause}>
-          <View className="h-20 w-24 rounded-3xl bg-[#FFF0F0] border border-[#F567674D] items-center justify-center">
-            <View className="items-center gap-1.5">
-              <Ionicons name={isPaused ? "play-circle" : "pause-circle"} size={28} color="#F87171" />
-              <Text className="text-red-400 font-inter font-bold text-[13px]">
-                {isPaused ? "Resume" : "Pause"}
-              </Text>
-            </View>
+          <View className="h-20 w-24 rounded-3xl bg-[#FFF0F0] border border-[#F567674D] items-center justify-center gap-1.5">
+            <Ionicons name={isPaused ? "play-circle" : "pause-circle"} size={28} color="#F87171" />
+            <Text className="text-red-400 font-inter font-bold text-[13px]">
+              {isPaused ? "Resume" : "Pause"}
+            </Text>
           </View>
         </Pressable>
       ) : (
         <>
           <Pressable onPress={onMode}>
-            <View className="h-20 w-24 rounded-3xl bg-blue-50 border border-blue-300 items-center justify-center">
-              <View className="items-center gap-1">
-                <MaterialCommunityIcons name="cog" size={24} color="#53A8FF" />
-                <Text className="text-blue-400 font-inter font-semibold text-[13px]">
-                  {t("taskCard.modes")}
-                </Text>
-              </View>
+            <View className="h-20 w-24 rounded-3xl bg-blue-50 border border-blue-300 items-center justify-center gap-1">
+              <MaterialCommunityIcons name="cog" size={24} color="#53A8FF" />
+              <Text className="text-blue-400 font-inter font-semibold text-[13px]">
+                {t("taskCard.modes")}
+              </Text>
             </View>
           </Pressable>
 
           <Pressable onPress={onFocus}>
-            <View className="h-20 w-24 rounded-3xl bg-orange-50 border border-orange-300 items-center justify-center">
-              <View className="items-center gap-1">
-                <MaterialCommunityIcons name="clock" size={24} color="#FFAA4A" />
-                <Text className="text-orange-400 font-inter font-semibold text-[13px]">
-                  {t("taskCard.focus")}
-                </Text>
-              </View>
+            <View className="h-20 w-24 rounded-3xl bg-orange-50 border border-orange-300 items-center justify-center gap-1">
+              <MaterialCommunityIcons name="clock" size={24} color="#FFAA4A" />
+              <Text className="text-orange-400 font-inter font-semibold text-[13px]">
+                {t("taskCard.focus")}
+              </Text>
             </View>
           </Pressable>
         </>


### PR DESCRIPTION
## Summary

Fix Android task-card left swipe Pomodoro actions not responding to taps.

The left swipe Mode and Focus buttons were visible on Android but did not receive press events when rendered inside ReanimatedSwipeable. This PR switches those action buttons to react-native-gesture-handler Pressable while preserving the previous layout and styling through the inner Tailwind-styled View.

## Release note

<!--
Write ONE sentence a normal user would understand — or "none".
Then tick exactly ONE status below. This feeds the user-facing release notes
("What's New"), so please be accurate about whether users actually see this.
-->

> Fixed an Android issue where task swipe actions for Pomodoro mode and focus could not be tapped.

**Status:**

- [x] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce
