### PR TITLE
Fix AI voice recording submission races

### DIFF
--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
@@ -23,14 +23,7 @@ const ERROR_CODE_TO_I18N_KEY: Record<string, string> = {
   NoTasksExtracted: "errors.noTasksExtracted",
 };
 
-const CONNECTION_READY_TIMEOUT_MS = 10_000;
 const CONNECTION_NOT_READY_ERROR_CODE = "ConnectionNotReady";
-
-type ConnectionReadyWaiter = {
-  resolve: (connection: signalR.HubConnection) => void;
-  reject: (error: Error) => void;
-  timeoutId: ReturnType<typeof setTimeout>;
-};
 
 export function useAiTaskGenerator({
   setIsAiGenerating,
@@ -39,54 +32,17 @@ export function useAiTaskGenerator({
 }) {
   const { t } = useTranslation("aiTaskGenerate");
   const [connection, setConnection] = useState<signalR.HubConnection | null>(null);
-  const [isConnectionReady, setIsConnectionReady] = useState(false);
   const [transcript, setTranscript] = useState<string | undefined>();
   const [streamedTasks, setStreamedTasks] = useState<ExtractedTaskDTO[]>([]);
   const [streamedNotes, setStreamedNotes] = useState<AiNoteDTO[]>([]);
   const [turns, setTurns] = useState<AiTaskGenerationTurn[]>([]);
   const requestStartedAtRef = useRef<number | null>(null);
   const pendingInputModeRef = useRef<AiTaskInputMode | null>(null);
-  const connectionRef = useRef<signalR.HubConnection | null>(null);
-  const connectionReadyWaitersRef = useRef<ConnectionReadyWaiter[]>([]);
-
-  const resolveConnectionReadyWaiters = useCallback((readyConnection: signalR.HubConnection) => {
-    const waiters = connectionReadyWaitersRef.current;
-    connectionReadyWaitersRef.current = [];
-    waiters.forEach((waiter) => {
-      clearTimeout(waiter.timeoutId);
-      waiter.resolve(readyConnection);
-    });
-  }, []);
-
-  const rejectConnectionReadyWaiters = useCallback((error: Error) => {
-    const waiters = connectionReadyWaitersRef.current;
-    connectionReadyWaitersRef.current = [];
-    waiters.forEach((waiter) => {
-      clearTimeout(waiter.timeoutId);
-      waiter.reject(error);
-    });
-  }, []);
-
-  const waitForConnectionReady = useCallback((): Promise<signalR.HubConnection> => {
-    const readyConnection = connectionRef.current;
-    if (readyConnection?.state === signalR.HubConnectionState.Connected) {
-      return Promise.resolve(readyConnection);
-    }
-
-    return new Promise((resolve, reject) => {
-      const timeoutId = setTimeout(() => {
-        connectionReadyWaitersRef.current = connectionReadyWaitersRef.current.filter(
-          (waiter) => waiter.timeoutId !== timeoutId,
-        );
-        reject(new Error(CONNECTION_NOT_READY_ERROR_CODE));
-      }, CONNECTION_READY_TIMEOUT_MS);
-
-      connectionReadyWaitersRef.current.push({ resolve, reject, timeoutId });
-    });
-  }, []);
 
   const submitAudioForTranscription = async (uri: string): Promise<void> => {
-    const readyConnection = await waitForConnectionReady();
+    if (!connection || connection.state !== signalR.HubConnectionState.Connected) {
+      throw new Error(CONNECTION_NOT_READY_ERROR_CODE);
+    }
 
     const arrayBuffer = await new ExpoFile(uri).arrayBuffer();
     const base64 = arrayBufferToBase64(arrayBuffer);
@@ -97,7 +53,7 @@ export function useAiTaskGenerator({
     pendingInputModeRef.current = "voice";
 
     try {
-      await signalRService.invoke(readyConnection, "TranscribeAudio", base64);
+      await signalRService.invoke(connection, "TranscribeAudio", base64);
     } catch (error) {
       console.error("TranscribeAudio invocation failed:", error);
       setIsAiGenerating(false);
@@ -115,12 +71,7 @@ export function useAiTaskGenerator({
   };
 
   const sendTextMessage = async (text: string) => {
-    if (
-      !text.trim() ||
-      !connection ||
-      !isConnectionReady ||
-      connection.state !== signalR.HubConnectionState.Connected
-    ) {
+    if (!text.trim() || !connection || connection.state !== signalR.HubConnectionState.Connected) {
       return;
     }
 
@@ -202,7 +153,6 @@ export function useAiTaskGenerator({
       .createConnection()
       .then(async (newConn) => {
         conn = newConn;
-        connectionRef.current = conn;
         conn.on("ReceiveGenerationResult", generationCompleteHandler);
         conn.on("ReceiveGenerationError", generationErrorHandler);
         conn.on("ReceiveTranscript", (text: string) => {
@@ -217,18 +167,10 @@ export function useAiTaskGenerator({
           setStreamedNotes((prev) => [...prev, note]);
         });
 
-        conn.onreconnecting(() => {
-          setIsConnectionReady(false);
-        });
-        conn.onreconnected(() => {
-          setIsConnectionReady(true);
-          if (conn) {
-            resolveConnectionReadyWaiters(conn);
-          }
-        });
         conn.onclose(() => {
-          setIsConnectionReady(false);
-          rejectConnectionReadyWaiters(new Error(CONNECTION_NOT_READY_ERROR_CODE));
+          if (!isDisposed) {
+            setConnection(null);
+          }
         });
 
         await conn.start();
@@ -238,19 +180,12 @@ export function useAiTaskGenerator({
         }
 
         setConnection(conn);
-        setIsConnectionReady(true);
-        resolveConnectionReadyWaiters(conn);
       })
-      .catch((error) => {
-        console.error("Error connecting to SignalR:", error);
-        rejectConnectionReadyWaiters(new Error(CONNECTION_NOT_READY_ERROR_CODE));
-      });
+      .catch((error) => console.error("Error connecting to SignalR:", error));
 
     return () => {
       isDisposed = true;
-      setIsConnectionReady(false);
-      connectionRef.current = null;
-      rejectConnectionReadyWaiters(new Error(CONNECTION_NOT_READY_ERROR_CODE));
+      setConnection(null);
       if (conn) {
         conn.off("ReceiveGenerationResult", generationCompleteHandler);
         conn.off("ReceiveGenerationError", generationErrorHandler);
@@ -260,19 +195,13 @@ export function useAiTaskGenerator({
         conn.stop().catch((error) => console.error("Error stopping SignalR connection:", error));
       }
     };
-  }, [
-    generationCompleteHandler,
-    generationErrorHandler,
-    rejectConnectionReadyWaiters,
-    resolveConnectionReadyWaiters,
-  ]);
+  }, [generationCompleteHandler, generationErrorHandler]);
 
   return {
     transcript,
     streamedTasks,
     streamedNotes,
     turns,
-    isConnectionReady,
     submitAudioForTranscription,
     sendTextMessage,
   };

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import * as signalR from "@microsoft/signalr";
 import { File as ExpoFile } from "expo-file-system";
 import { signalRService } from "@/feature/ai-task-generate/services/ai-task-generator-signalr-service";
@@ -98,52 +98,46 @@ export function useAiTaskGenerator({
     }
   };
 
-  const generationCompleteHandler = useCallback(
-    (result: AiResultMessageDTO) => {
-      setTranscript(undefined);
-      setIsAiGenerating(false);
-      requestStartedAtRef.current = null;
-      const inputMode = pendingInputModeRef.current;
-      pendingInputModeRef.current = null;
-      const inputText = result.userInput;
+  const generationCompleteHandler = (result: AiResultMessageDTO) => {
+    setTranscript(undefined);
+    setIsAiGenerating(false);
+    requestStartedAtRef.current = null;
+    const inputMode = pendingInputModeRef.current;
+    pendingInputModeRef.current = null;
+    const inputText = result.userInput;
 
-      if (inputMode && inputText) {
-        setTurns((prev) => [...prev, buildTurn(prev.length + 1, inputMode, result)]);
-      }
+    if (inputMode && inputText) {
+      setTurns((prev) => [...prev, buildTurn(prev.length + 1, inputMode, result)]);
+    }
 
-      // Sync to authoritative final list — streaming only covers CreateTask, not RemoveTask/UpdateTask
-      setStreamedTasks(result.extractedTasks ?? []);
-      setStreamedNotes(result.extractedNotes ?? []);
-    },
-    [setIsAiGenerating],
-  );
+    // Sync to authoritative final list — streaming only covers CreateTask, not RemoveTask/UpdateTask
+    setStreamedTasks(result.extractedTasks ?? []);
+    setStreamedNotes(result.extractedNotes ?? []);
+  };
 
-  const generationErrorHandler = useCallback(
-    (error: AiGenerationErrorDTO) => {
-      setTranscript(undefined);
-      setIsAiGenerating(false);
-      const startedAt = requestStartedAtRef.current;
-      requestStartedAtRef.current = null;
-      const inputMode = pendingInputModeRef.current;
-      pendingInputModeRef.current = null;
-      setStreamedTasks([]);
-      setStreamedNotes([]);
+  const generationErrorHandler = (error: AiGenerationErrorDTO) => {
+    setTranscript(undefined);
+    setIsAiGenerating(false);
+    const startedAt = requestStartedAtRef.current;
+    requestStartedAtRef.current = null;
+    const inputMode = pendingInputModeRef.current;
+    pendingInputModeRef.current = null;
+    setStreamedTasks([]);
+    setStreamedNotes([]);
 
-      analytics.trackAiTaskGenerationFailed({
-        inputMode: inputMode ?? "unknown",
-        stage:
-          error.errorCode === "TranscriptionFailed" || error.errorCode === "EmptyAudio"
-            ? "transcription"
-            : "generation",
-        errorCode: error.errorCode,
-        durationMs: startedAt !== null ? Date.now() - startedAt : undefined,
-      });
+    analytics.trackAiTaskGenerationFailed({
+      inputMode: inputMode ?? "unknown",
+      stage:
+        error.errorCode === "TranscriptionFailed" || error.errorCode === "EmptyAudio"
+          ? "transcription"
+          : "generation",
+      errorCode: error.errorCode,
+      durationMs: startedAt !== null ? Date.now() - startedAt : undefined,
+    });
 
-      const i18nKey = ERROR_CODE_TO_I18N_KEY[error.errorCode] ?? "errors.default";
-      Toast.show({ type: "error", text1: t(i18nKey) });
-    },
-    [setIsAiGenerating, t],
-  );
+    const i18nKey = ERROR_CODE_TO_I18N_KEY[error.errorCode] ?? "errors.default";
+    Toast.show({ type: "error", text1: t(i18nKey) });
+  };
 
   useEffect(() => {
     let conn: signalR.HubConnection | null = null;
@@ -181,7 +175,7 @@ export function useAiTaskGenerator({
         conn.stop().catch((error) => console.error("Error stopping SignalR connection:", error));
       }
     };
-  }, [generationCompleteHandler, generationErrorHandler]);
+  }, []);
 
   return {
     transcript,

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import * as signalR from "@microsoft/signalr";
 import { File as ExpoFile } from "expo-file-system";
 import { signalRService } from "@/feature/ai-task-generate/services/ai-task-generator-signalr-service";
@@ -98,11 +98,8 @@ export function useAiTaskGenerator({
     }
   };
 
-  useEffect(() => {
-    let conn: signalR.HubConnection | null = null;
-    let isDisposed = false;
-
-    const generationCompleteHandler = (result: AiResultMessageDTO) => {
+  const generationCompleteHandler = useCallback(
+    (result: AiResultMessageDTO) => {
       setTranscript(undefined);
       setIsAiGenerating(false);
       requestStartedAtRef.current = null;
@@ -117,9 +114,12 @@ export function useAiTaskGenerator({
       // Sync to authoritative final list — streaming only covers CreateTask, not RemoveTask/UpdateTask
       setStreamedTasks(result.extractedTasks ?? []);
       setStreamedNotes(result.extractedNotes ?? []);
-    };
+    },
+    [setIsAiGenerating],
+  );
 
-    const generationErrorHandler = (error: AiGenerationErrorDTO) => {
+  const generationErrorHandler = useCallback(
+    (error: AiGenerationErrorDTO) => {
       setTranscript(undefined);
       setIsAiGenerating(false);
       const startedAt = requestStartedAtRef.current;
@@ -141,7 +141,13 @@ export function useAiTaskGenerator({
 
       const i18nKey = ERROR_CODE_TO_I18N_KEY[error.errorCode] ?? "errors.default";
       Toast.show({ type: "error", text1: t(i18nKey) });
-    };
+    },
+    [setIsAiGenerating, t],
+  );
+
+  useEffect(() => {
+    let conn: signalR.HubConnection | null = null;
+    let isDisposed = false;
 
     signalRService
       .createConnection()
@@ -182,7 +188,7 @@ export function useAiTaskGenerator({
         conn.stop().catch((error) => console.error("Error stopping SignalR connection:", error));
       }
     };
-  }, [setIsAiGenerating, t]);
+  }, [generationCompleteHandler, generationErrorHandler]);
 
   return {
     transcript,

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
@@ -14,6 +14,15 @@ import Toast from "react-native-toast-message";
 import type { AiTaskGenerationTurn, AiTaskInputMode } from "@/shared/constants/posthog-events";
 import { analytics } from "@/shared/services/analytics";
 
+const ERROR_CODE_TO_I18N_KEY: Record<string, string> = {
+  TranscriptionFailed: "errors.transcriptionFailed",
+  EmptyAudio: "errors.emptyAudio",
+  TokenLimited: "errors.tokenLimited",
+  BlockedByContentFilter: "errors.contentFilter",
+  Canceled: "errors.canceled",
+  NoTasksExtracted: "errors.noTasksExtracted",
+};
+
 const CONNECTION_NOT_READY_ERROR_CODE = "ConnectionNotReady";
 
 export function useAiTaskGenerator({
@@ -125,6 +134,9 @@ export function useAiTaskGenerator({
       errorCode: error.errorCode,
       durationMs: startedAt !== null ? Date.now() - startedAt : undefined,
     });
+
+    const i18nKey = ERROR_CODE_TO_I18N_KEY[error.errorCode] ?? "errors.default";
+    Toast.show({ type: "error", text1: t(i18nKey) });
   };
 
   useEffect(() => {

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
@@ -173,7 +173,6 @@ export function useAiTaskGenerator({
 
     return () => {
       isDisposed = true;
-      setConnection(null);
       if (conn) {
         conn.off("ReceiveGenerationResult", generationCompleteHandler);
         conn.off("ReceiveGenerationError", generationErrorHandler);

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
@@ -147,7 +147,6 @@ export function useAiTaskGenerator({
 
   useEffect(() => {
     let conn: signalR.HubConnection | null = null;
-    let isDisposed = false;
 
     signalRService
       .createConnection()
@@ -168,17 +167,11 @@ export function useAiTaskGenerator({
         });
 
         await conn.start();
-        if (isDisposed) {
-          await conn.stop();
-          return;
-        }
-
         setConnection(conn);
       })
       .catch((error) => console.error("Error connecting to SignalR:", error));
 
     return () => {
-      isDisposed = true;
       if (conn) {
         conn.off("ReceiveGenerationResult", generationCompleteHandler);
         conn.off("ReceiveGenerationError", generationErrorHandler);

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
@@ -23,6 +23,15 @@ const ERROR_CODE_TO_I18N_KEY: Record<string, string> = {
   NoTasksExtracted: "errors.noTasksExtracted",
 };
 
+const CONNECTION_READY_TIMEOUT_MS = 10_000;
+const CONNECTION_NOT_READY_ERROR_CODE = "ConnectionNotReady";
+
+type ConnectionReadyWaiter = {
+  resolve: (connection: signalR.HubConnection) => void;
+  reject: (error: Error) => void;
+  timeoutId: ReturnType<typeof setTimeout>;
+};
+
 export function useAiTaskGenerator({
   setIsAiGenerating,
 }: {
@@ -37,15 +46,47 @@ export function useAiTaskGenerator({
   const [turns, setTurns] = useState<AiTaskGenerationTurn[]>([]);
   const requestStartedAtRef = useRef<number | null>(null);
   const pendingInputModeRef = useRef<AiTaskInputMode | null>(null);
+  const connectionRef = useRef<signalR.HubConnection | null>(null);
+  const connectionReadyWaitersRef = useRef<ConnectionReadyWaiter[]>([]);
+
+  const resolveConnectionReadyWaiters = useCallback((readyConnection: signalR.HubConnection) => {
+    const waiters = connectionReadyWaitersRef.current;
+    connectionReadyWaitersRef.current = [];
+    waiters.forEach((waiter) => {
+      clearTimeout(waiter.timeoutId);
+      waiter.resolve(readyConnection);
+    });
+  }, []);
+
+  const rejectConnectionReadyWaiters = useCallback((error: Error) => {
+    const waiters = connectionReadyWaitersRef.current;
+    connectionReadyWaitersRef.current = [];
+    waiters.forEach((waiter) => {
+      clearTimeout(waiter.timeoutId);
+      waiter.reject(error);
+    });
+  }, []);
+
+  const waitForConnectionReady = useCallback((): Promise<signalR.HubConnection> => {
+    const readyConnection = connectionRef.current;
+    if (readyConnection?.state === signalR.HubConnectionState.Connected) {
+      return Promise.resolve(readyConnection);
+    }
+
+    return new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        connectionReadyWaitersRef.current = connectionReadyWaitersRef.current.filter(
+          (waiter) => waiter.timeoutId !== timeoutId,
+        );
+        reject(new Error(CONNECTION_NOT_READY_ERROR_CODE));
+      }, CONNECTION_READY_TIMEOUT_MS);
+
+      connectionReadyWaitersRef.current.push({ resolve, reject, timeoutId });
+    });
+  }, []);
 
   const submitAudioForTranscription = async (uri: string): Promise<void> => {
-    if (
-      !connection ||
-      !isConnectionReady ||
-      connection.state !== signalR.HubConnectionState.Connected
-    ) {
-      throw new Error("Cannot submit audio: not connected.");
-    }
+    const readyConnection = await waitForConnectionReady();
 
     const arrayBuffer = await new ExpoFile(uri).arrayBuffer();
     const base64 = arrayBufferToBase64(arrayBuffer);
@@ -56,7 +97,7 @@ export function useAiTaskGenerator({
     pendingInputModeRef.current = "voice";
 
     try {
-      await signalRService.invoke(connection, "TranscribeAudio", base64);
+      await signalRService.invoke(readyConnection, "TranscribeAudio", base64);
     } catch (error) {
       console.error("TranscribeAudio invocation failed:", error);
       setIsAiGenerating(false);
@@ -108,6 +149,7 @@ export function useAiTaskGenerator({
 
   const generationCompleteHandler = useCallback(
     (result: AiResultMessageDTO) => {
+      setTranscript(undefined);
       setIsAiGenerating(false);
       requestStartedAtRef.current = null;
       const inputMode = pendingInputModeRef.current;
@@ -127,6 +169,7 @@ export function useAiTaskGenerator({
 
   const generationErrorHandler = useCallback(
     (error: AiGenerationErrorDTO) => {
+      setTranscript(undefined);
       setIsAiGenerating(false);
       const startedAt = requestStartedAtRef.current;
       requestStartedAtRef.current = null;
@@ -159,6 +202,7 @@ export function useAiTaskGenerator({
       .createConnection()
       .then(async (newConn) => {
         conn = newConn;
+        connectionRef.current = conn;
         conn.on("ReceiveGenerationResult", generationCompleteHandler);
         conn.on("ReceiveGenerationError", generationErrorHandler);
         conn.on("ReceiveTranscript", (text: string) => {
@@ -178,9 +222,13 @@ export function useAiTaskGenerator({
         });
         conn.onreconnected(() => {
           setIsConnectionReady(true);
+          if (conn) {
+            resolveConnectionReadyWaiters(conn);
+          }
         });
         conn.onclose(() => {
           setIsConnectionReady(false);
+          rejectConnectionReadyWaiters(new Error(CONNECTION_NOT_READY_ERROR_CODE));
         });
 
         await conn.start();
@@ -191,12 +239,18 @@ export function useAiTaskGenerator({
 
         setConnection(conn);
         setIsConnectionReady(true);
+        resolveConnectionReadyWaiters(conn);
       })
-      .catch((error) => console.error("Error connecting to SignalR:", error));
+      .catch((error) => {
+        console.error("Error connecting to SignalR:", error);
+        rejectConnectionReadyWaiters(new Error(CONNECTION_NOT_READY_ERROR_CODE));
+      });
 
     return () => {
       isDisposed = true;
       setIsConnectionReady(false);
+      connectionRef.current = null;
+      rejectConnectionReadyWaiters(new Error(CONNECTION_NOT_READY_ERROR_CODE));
       if (conn) {
         conn.off("ReceiveGenerationResult", generationCompleteHandler);
         conn.off("ReceiveGenerationError", generationErrorHandler);
@@ -206,7 +260,12 @@ export function useAiTaskGenerator({
         conn.stop().catch((error) => console.error("Error stopping SignalR connection:", error));
       }
     };
-  }, [generationCompleteHandler, generationErrorHandler]);
+  }, [
+    generationCompleteHandler,
+    generationErrorHandler,
+    rejectConnectionReadyWaiters,
+    resolveConnectionReadyWaiters,
+  ]);
 
   return {
     transcript,

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import * as signalR from "@microsoft/signalr";
 import { File as ExpoFile } from "expo-file-system";
 import { signalRService } from "@/feature/ai-task-generate/services/ai-task-generator-signalr-service";
@@ -30,6 +30,7 @@ export function useAiTaskGenerator({
 }) {
   const { t } = useTranslation("aiTaskGenerate");
   const [connection, setConnection] = useState<signalR.HubConnection | null>(null);
+  const [isConnectionReady, setIsConnectionReady] = useState(false);
   const [transcript, setTranscript] = useState<string | undefined>();
   const [streamedTasks, setStreamedTasks] = useState<ExtractedTaskDTO[]>([]);
   const [streamedNotes, setStreamedNotes] = useState<AiNoteDTO[]>([]);
@@ -38,7 +39,13 @@ export function useAiTaskGenerator({
   const pendingInputModeRef = useRef<AiTaskInputMode | null>(null);
 
   const submitAudioForTranscription = async (uri: string): Promise<void> => {
-    if (!connection) throw new Error("Cannot submit audio: not connected.");
+    if (
+      !connection ||
+      !isConnectionReady ||
+      connection.state !== signalR.HubConnectionState.Connected
+    ) {
+      throw new Error("Cannot submit audio: not connected.");
+    }
 
     const arrayBuffer = await new ExpoFile(uri).arrayBuffer();
     const base64 = arrayBufferToBase64(arrayBuffer);
@@ -53,18 +60,28 @@ export function useAiTaskGenerator({
     } catch (error) {
       console.error("TranscribeAudio invocation failed:", error);
       setIsAiGenerating(false);
+      const startedAt = requestStartedAtRef.current;
+      requestStartedAtRef.current = null;
+      pendingInputModeRef.current = null;
       analytics.trackAiTaskGenerationFailed({
         inputMode: "voice",
         stage: "transcription",
         errorCode: "NetworkError",
-        durationMs: Date.now() - (requestStartedAtRef.current ?? Date.now()),
+        durationMs: startedAt !== null ? Date.now() - startedAt : undefined,
       });
       Toast.show({ type: "error", text1: t("errors.default") });
     }
   };
 
   const sendTextMessage = async (text: string) => {
-    if (!text.trim() || !connection) return;
+    if (
+      !text.trim() ||
+      !connection ||
+      !isConnectionReady ||
+      connection.state !== signalR.HubConnectionState.Connected
+    ) {
+      return;
+    }
 
     setTranscript(undefined);
     setIsAiGenerating(true);
@@ -76,65 +93,72 @@ export function useAiTaskGenerator({
     } catch (error) {
       console.error("SendMessage invocation failed:", error);
       setIsAiGenerating(false);
+      const startedAt = requestStartedAtRef.current;
+      requestStartedAtRef.current = null;
+      pendingInputModeRef.current = null;
       analytics.trackAiTaskGenerationFailed({
         inputMode: "text",
         stage: "send",
         errorCode: "NetworkError",
-        durationMs: Date.now() - (requestStartedAtRef.current ?? Date.now()),
+        durationMs: startedAt !== null ? Date.now() - startedAt : undefined,
       });
       Toast.show({ type: "error", text1: t("errors.default") });
     }
   };
 
-  const generationCompleteHandler = (result: AiResultMessageDTO) => {
-    setTranscript(undefined);
-    setIsAiGenerating(false);
-    requestStartedAtRef.current = null;
-    const inputMode = pendingInputModeRef.current;
-    pendingInputModeRef.current = null;
-    const inputText = result.userInput;
+  const generationCompleteHandler = useCallback(
+    (result: AiResultMessageDTO) => {
+      setIsAiGenerating(false);
+      requestStartedAtRef.current = null;
+      const inputMode = pendingInputModeRef.current;
+      pendingInputModeRef.current = null;
+      const inputText = result.userInput;
 
-    if (inputMode && inputText) {
-      setTurns((prev) => [...prev, buildTurn(prev.length + 1, inputMode, result)]);
-    }
+      if (inputMode && inputText) {
+        setTurns((prev) => [...prev, buildTurn(prev.length + 1, inputMode, result)]);
+      }
 
-    // Sync to authoritative final list — streaming only covers CreateTask, not RemoveTask/UpdateTask
-    setStreamedTasks(result.extractedTasks ?? []);
-    setStreamedNotes(result.extractedNotes ?? []);
-  };
+      // Sync to authoritative final list — streaming only covers CreateTask, not RemoveTask/UpdateTask
+      setStreamedTasks(result.extractedTasks ?? []);
+      setStreamedNotes(result.extractedNotes ?? []);
+    },
+    [setIsAiGenerating],
+  );
 
-  const generationErrorHandler = (error: AiGenerationErrorDTO) => {
-    setTranscript(undefined);
-    setIsAiGenerating(false);
-    const startedAt = requestStartedAtRef.current;
-    requestStartedAtRef.current = null;
-    const inputMode = pendingInputModeRef.current;
-    pendingInputModeRef.current = null;
-    setStreamedTasks([]);
-    setStreamedNotes([]);
+  const generationErrorHandler = useCallback(
+    (error: AiGenerationErrorDTO) => {
+      setIsAiGenerating(false);
+      const startedAt = requestStartedAtRef.current;
+      requestStartedAtRef.current = null;
+      const inputMode = pendingInputModeRef.current;
+      pendingInputModeRef.current = null;
+      setStreamedTasks([]);
+      setStreamedNotes([]);
 
-    analytics.trackAiTaskGenerationFailed({
-      inputMode: inputMode ?? "unknown",
-      stage:
-        error.errorCode === "TranscriptionFailed" || error.errorCode === "EmptyAudio"
-          ? "transcription"
-          : "generation",
-      errorCode: error.errorCode,
-      durationMs: startedAt !== null ? Date.now() - startedAt : undefined,
-    });
+      analytics.trackAiTaskGenerationFailed({
+        inputMode: inputMode ?? "unknown",
+        stage:
+          error.errorCode === "TranscriptionFailed" || error.errorCode === "EmptyAudio"
+            ? "transcription"
+            : "generation",
+        errorCode: error.errorCode,
+        durationMs: startedAt !== null ? Date.now() - startedAt : undefined,
+      });
 
-    const i18nKey = ERROR_CODE_TO_I18N_KEY[error.errorCode] ?? "errors.default";
-    Toast.show({ type: "error", text1: t(i18nKey) });
-  };
+      const i18nKey = ERROR_CODE_TO_I18N_KEY[error.errorCode] ?? "errors.default";
+      Toast.show({ type: "error", text1: t(i18nKey) });
+    },
+    [setIsAiGenerating, t],
+  );
 
   useEffect(() => {
     let conn: signalR.HubConnection | null = null;
+    let isDisposed = false;
 
     signalRService
       .createConnection()
-      .then((newConn) => {
+      .then(async (newConn) => {
         conn = newConn;
-        setConnection(conn);
         conn.on("ReceiveGenerationResult", generationCompleteHandler);
         conn.on("ReceiveGenerationError", generationErrorHandler);
         conn.on("ReceiveTranscript", (text: string) => {
@@ -148,11 +172,31 @@ export function useAiTaskGenerator({
           if (requestStartedAtRef.current == null) return;
           setStreamedNotes((prev) => [...prev, note]);
         });
-        return conn.start();
+
+        conn.onreconnecting(() => {
+          setIsConnectionReady(false);
+        });
+        conn.onreconnected(() => {
+          setIsConnectionReady(true);
+        });
+        conn.onclose(() => {
+          setIsConnectionReady(false);
+        });
+
+        await conn.start();
+        if (isDisposed) {
+          await conn.stop();
+          return;
+        }
+
+        setConnection(conn);
+        setIsConnectionReady(true);
       })
       .catch((error) => console.error("Error connecting to SignalR:", error));
 
     return () => {
+      isDisposed = true;
+      setIsConnectionReady(false);
       if (conn) {
         conn.off("ReceiveGenerationResult", generationCompleteHandler);
         conn.off("ReceiveGenerationError", generationErrorHandler);
@@ -162,13 +206,14 @@ export function useAiTaskGenerator({
         conn.stop().catch((error) => console.error("Error stopping SignalR connection:", error));
       }
     };
-  }, []);
+  }, [generationCompleteHandler, generationErrorHandler]);
 
   return {
     transcript,
     streamedTasks,
     streamedNotes,
     turns,
+    isConnectionReady,
     submitAudioForTranscription,
     sendTextMessage,
   };

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
@@ -14,15 +14,6 @@ import Toast from "react-native-toast-message";
 import type { AiTaskGenerationTurn, AiTaskInputMode } from "@/shared/constants/posthog-events";
 import { analytics } from "@/shared/services/analytics";
 
-const ERROR_CODE_TO_I18N_KEY: Record<string, string> = {
-  TranscriptionFailed: "errors.transcriptionFailed",
-  EmptyAudio: "errors.emptyAudio",
-  TokenLimited: "errors.tokenLimited",
-  BlockedByContentFilter: "errors.contentFilter",
-  Canceled: "errors.canceled",
-  NoTasksExtracted: "errors.noTasksExtracted",
-};
-
 const CONNECTION_NOT_READY_ERROR_CODE = "ConnectionNotReady";
 
 export function useAiTaskGenerator({
@@ -134,9 +125,6 @@ export function useAiTaskGenerator({
       errorCode: error.errorCode,
       durationMs: startedAt !== null ? Date.now() - startedAt : undefined,
     });
-
-    const i18nKey = ERROR_CODE_TO_I18N_KEY[error.errorCode] ?? "errors.default";
-    Toast.show({ type: "error", text1: t(i18nKey) });
   };
 
   useEffect(() => {

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import * as signalR from "@microsoft/signalr";
 import { File as ExpoFile } from "expo-file-system";
 import { signalRService } from "@/feature/ai-task-generate/services/ai-task-generator-signalr-service";
@@ -98,8 +98,11 @@ export function useAiTaskGenerator({
     }
   };
 
-  const generationCompleteHandler = useCallback(
-    (result: AiResultMessageDTO) => {
+  useEffect(() => {
+    let conn: signalR.HubConnection | null = null;
+    let isDisposed = false;
+
+    const generationCompleteHandler = (result: AiResultMessageDTO) => {
       setTranscript(undefined);
       setIsAiGenerating(false);
       requestStartedAtRef.current = null;
@@ -114,12 +117,9 @@ export function useAiTaskGenerator({
       // Sync to authoritative final list — streaming only covers CreateTask, not RemoveTask/UpdateTask
       setStreamedTasks(result.extractedTasks ?? []);
       setStreamedNotes(result.extractedNotes ?? []);
-    },
-    [setIsAiGenerating],
-  );
+    };
 
-  const generationErrorHandler = useCallback(
-    (error: AiGenerationErrorDTO) => {
+    const generationErrorHandler = (error: AiGenerationErrorDTO) => {
       setTranscript(undefined);
       setIsAiGenerating(false);
       const startedAt = requestStartedAtRef.current;
@@ -141,13 +141,7 @@ export function useAiTaskGenerator({
 
       const i18nKey = ERROR_CODE_TO_I18N_KEY[error.errorCode] ?? "errors.default";
       Toast.show({ type: "error", text1: t(i18nKey) });
-    },
-    [setIsAiGenerating, t],
-  );
-
-  useEffect(() => {
-    let conn: signalR.HubConnection | null = null;
-    let isDisposed = false;
+    };
 
     signalRService
       .createConnection()
@@ -165,12 +159,6 @@ export function useAiTaskGenerator({
         conn.on("ReceiveNoteExtracted", (note: AiNoteDTO) => {
           if (requestStartedAtRef.current == null) return;
           setStreamedNotes((prev) => [...prev, note]);
-        });
-
-        conn.onclose(() => {
-          if (!isDisposed) {
-            setConnection(null);
-          }
         });
 
         await conn.start();
@@ -195,7 +183,7 @@ export function useAiTaskGenerator({
         conn.stop().catch((error) => console.error("Error stopping SignalR connection:", error));
       }
     };
-  }, [generationCompleteHandler, generationErrorHandler]);
+  }, [setIsAiGenerating, t]);
 
   return {
     transcript,

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
@@ -10,8 +10,6 @@ import { useTranslation } from "react-i18next";
 import Toast from "react-native-toast-message";
 import { analytics } from "@/shared/services/analytics";
 
-const CONNECTION_NOT_READY_ERROR_CODE = "ConnectionNotReady";
-
 export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => Promise<void>) {
   const { t } = useTranslation("aiTaskGenerate");
   const recorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);
@@ -99,10 +97,7 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
       analytics.trackAiTaskGenerationFailed({
         inputMode: "voice",
         stage: "send",
-        errorCode:
-          error instanceof Error && error.message === CONNECTION_NOT_READY_ERROR_CODE
-            ? CONNECTION_NOT_READY_ERROR_CODE
-            : "AudioSubmitFailed",
+        errorCode: "AudioSubmitFailed",
       });
       return false;
     }

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
@@ -36,6 +36,15 @@ export function useVoiceInput({ submitAudio }: UseVoiceInputOptions) {
     });
   };
 
+  const releasePreparedRecording = async (): Promise<void> => {
+    try {
+      await recorder.stop();
+    } catch (error) {
+      console.warn("[Mic] Error releasing prepared recording.", error);
+      trackRecordingFailure("RecordingCancelFailed");
+    }
+  };
+
   const handlePressIn = () => {
     setIsHoldHintVisible(false);
     if (stateRef.current !== "idle" && stateRef.current !== "error") return;
@@ -53,6 +62,7 @@ export function useVoiceInput({ submitAudio }: UseVoiceInputOptions) {
       await setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true });
       await recorder.prepareToRecordAsync();
       if (!pressActiveRef.current) {
+        await releasePreparedRecording();
         setVoiceState("idle");
         return;
       }

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
@@ -92,7 +92,6 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
       await submitAudioForTranscription(uri);
     } catch (error) {
       console.warn("[Mic] Error submitting audio for transcription.", error);
-      Toast.show({ type: "error", text1: t("errors.default") });
       analytics.trackAiTaskGenerationFailed({
         inputMode: "voice",
         stage: "send",

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
@@ -18,7 +18,6 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
   const { isRecording } = useAudioRecorderState(recorder);
   // Release handlers wait on this so they never race ahead of async recorder setup.
   const startPromiseRef = useRef<Promise<void> | null>(null);
-  const releaseRequestedRef = useRef(false);
 
   const trackRecordingFailure = (errorCode: string) => {
     analytics.trackAiTaskGenerationFailed({
@@ -29,7 +28,6 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
   };
 
   const startListening = () => {
-    releaseRequestedRef.current = false;
     const startPromise = startRecording();
     startPromiseRef.current = startPromise;
     void startPromise.finally(() => {
@@ -51,21 +49,12 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
     }
   };
 
-  const waitForStartAfterRelease = async (): Promise<boolean> => {
-    releaseRequestedRef.current = true;
+  const waitForStartAfterRelease = async (): Promise<void> => {
     await startPromiseRef.current;
-
-    if (!releaseRequestedRef.current) {
-      return false;
-    }
-
-    releaseRequestedRef.current = false;
-    return true;
   };
 
   const cancelListening = async (): Promise<void> => {
-    const shouldHandleRelease = await waitForStartAfterRelease();
-    if (!shouldHandleRelease) return;
+    await waitForStartAfterRelease();
 
     if (recorder.isRecording) {
       try {
@@ -78,8 +67,7 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
   };
 
   const stopAndUpload = async (): Promise<boolean> => {
-    const shouldHandleRelease = await waitForStartAfterRelease();
-    if (!shouldHandleRelease) return false;
+    await waitForStartAfterRelease();
 
     if (!recorder.isRecording) {
       Toast.show({ type: "error", text1: t("errors.emptyAudio") });

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
@@ -28,11 +28,15 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
     });
   };
 
-  const startListening = async () => {
+  const startListening = () => {
     releaseRequestedRef.current = false;
     const startPromise = startRecording();
     startPromiseRef.current = startPromise;
-    await startPromise;
+    void startPromise.finally(() => {
+      if (startPromiseRef.current === startPromise) {
+        startPromiseRef.current = null;
+      }
+    });
   };
 
   const startRecording = async (): Promise<void> => {
@@ -44,8 +48,6 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
       Toast.show({ type: "error", text1: t("errors.recordingFailed") });
       console.warn("[Mic] Error starting recording.", error);
       trackRecordingFailure("RecordingStartFailed");
-    } finally {
-      startPromiseRef.current = null;
     }
   };
 

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
@@ -1,32 +1,24 @@
-import { RecordingPresets, setAudioModeAsync, useAudioRecorder } from "expo-audio";
-import { useRef, useState } from "react";
+import {
+  RecordingPresets,
+  setAudioModeAsync,
+  useAudioRecorder,
+  useAudioRecorderState,
+} from "expo-audio";
+import { useRef } from "react";
 import { File as ExpoFile } from "expo-file-system";
 import { useTranslation } from "react-i18next";
 import Toast from "react-native-toast-message";
 import { analytics } from "@/shared/services/analytics";
 
-export type VoiceInputState = "idle" | "preparing" | "recording" | "stopping" | "sending" | "error";
-
 const CONNECTION_NOT_READY_ERROR_CODE = "ConnectionNotReady";
 
-type UseVoiceInputOptions = {
-  submitAudio: (uri: string) => Promise<void>;
-};
-
-export function useVoiceInput({ submitAudio }: UseVoiceInputOptions) {
+export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => Promise<void>) {
   const { t } = useTranslation("aiTaskGenerate");
   const recorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);
-  const [state, setState] = useState<VoiceInputState>("idle");
-  const [isHoldHintVisible, setIsHoldHintVisible] = useState(false);
-  const stateRef = useRef<VoiceInputState>("idle");
+  const { isRecording } = useAudioRecorderState(recorder);
+  // Release handlers wait on this so they never race ahead of async recorder setup.
   const startPromiseRef = useRef<Promise<void> | null>(null);
-  const pressActiveRef = useRef(false);
-  const recordingStartedRef = useRef(false);
-
-  const setVoiceState = (nextState: VoiceInputState) => {
-    stateRef.current = nextState;
-    setState(nextState);
-  };
+  const releaseRequestedRef = useRef(false);
 
   const trackRecordingFailure = (errorCode: string) => {
     analytics.trackAiTaskGenerationFailed({
@@ -36,41 +28,19 @@ export function useVoiceInput({ submitAudio }: UseVoiceInputOptions) {
     });
   };
 
-  const releasePreparedRecording = async (): Promise<void> => {
-    try {
-      await recorder.stop();
-    } catch (error) {
-      console.warn("[Mic] Error releasing prepared recording.", error);
-      trackRecordingFailure("RecordingCancelFailed");
-    }
-  };
-
-  const handlePressIn = () => {
-    setIsHoldHintVisible(false);
-    if (stateRef.current !== "idle" && stateRef.current !== "error") return;
-
-    pressActiveRef.current = true;
-    recordingStartedRef.current = false;
-    setVoiceState("preparing");
-
+  const startListening = async () => {
+    releaseRequestedRef.current = false;
     const startPromise = startRecording();
     startPromiseRef.current = startPromise;
+    await startPromise;
   };
 
   const startRecording = async (): Promise<void> => {
     try {
       await setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true });
       await recorder.prepareToRecordAsync();
-      if (!pressActiveRef.current) {
-        await releasePreparedRecording();
-        setVoiceState("idle");
-        return;
-      }
       recorder.record();
-      recordingStartedRef.current = true;
-      setVoiceState("recording");
     } catch (error) {
-      setVoiceState("error");
       Toast.show({ type: "error", text1: t("errors.recordingFailed") });
       console.warn("[Mic] Error starting recording.", error);
       trackRecordingFailure("RecordingStartFailed");
@@ -79,11 +49,23 @@ export function useVoiceInput({ submitAudio }: UseVoiceInputOptions) {
     }
   };
 
-  const cancel = async (): Promise<void> => {
-    pressActiveRef.current = false;
+  const waitForStartAfterRelease = async (): Promise<boolean> => {
+    releaseRequestedRef.current = true;
     await startPromiseRef.current;
 
-    if (recordingStartedRef.current) {
+    if (!releaseRequestedRef.current) {
+      return false;
+    }
+
+    releaseRequestedRef.current = false;
+    return true;
+  };
+
+  const cancelListening = async (): Promise<void> => {
+    const shouldHandleRelease = await waitForStartAfterRelease();
+    if (!shouldHandleRelease) return;
+
+    if (recorder.isRecording) {
       try {
         await recorder.stop();
       } catch (error) {
@@ -91,58 +73,37 @@ export function useVoiceInput({ submitAudio }: UseVoiceInputOptions) {
         trackRecordingFailure("RecordingCancelFailed");
       }
     }
-
-    recordingStartedRef.current = false;
-    startPromiseRef.current = null;
-    setVoiceState("idle");
   };
 
-  const handlePressOut = async (): Promise<boolean> => {
-    if (stateRef.current === "error" && !pressActiveRef.current && !recordingStartedRef.current) {
+  const stopAndUpload = async (): Promise<boolean> => {
+    const shouldHandleRelease = await waitForStartAfterRelease();
+    if (!shouldHandleRelease) return false;
+
+    if (!recorder.isRecording) {
+      Toast.show({ type: "error", text1: t("errors.emptyAudio") });
+      console.warn("[Mic] stopAndUpload called but recorder is not recording.");
+      trackRecordingFailure("NotRecording");
       return false;
     }
 
-    pressActiveRef.current = false;
-    await startPromiseRef.current;
-
-    if (stateRef.current === "error") {
-      return false;
-    }
-
-    if (!recordingStartedRef.current) {
-      startPromiseRef.current = null;
-      setIsHoldHintVisible(true);
-      setVoiceState("idle");
-      return false;
-    }
-
-    setVoiceState("stopping");
     try {
       await recorder.stop();
     } catch (error) {
-      setVoiceState("error");
       console.warn("[Mic] Error stopping recording.", error);
       trackRecordingFailure("RecordingStopFailed");
       return false;
     }
 
-    recordingStartedRef.current = false;
-    startPromiseRef.current = null;
-
     const uri = recorder.uri;
     if (!uri) {
-      setVoiceState("error");
       Toast.show({ type: "error", text1: t("errors.emptyAudio") });
       trackRecordingFailure("EmptyAudio");
       return false;
     }
 
-    setVoiceState("sending");
     try {
-      await submitAudio(uri);
-      setVoiceState("idle");
+      await submitAudioForTranscription(uri);
     } catch (error) {
-      setVoiceState("error");
       console.warn("[Mic] Error submitting audio for transcription.", error);
       Toast.show({ type: "error", text1: t("errors.default") });
       analytics.trackAiTaskGenerationFailed({
@@ -167,13 +128,9 @@ export function useVoiceInput({ submitAudio }: UseVoiceInputOptions) {
   };
 
   return {
-    state,
-    isRecording: state === "recording",
-    isBusy:
-      state === "preparing" || state === "recording" || state === "stopping" || state === "sending",
-    isHoldHintVisible,
-    handlePressIn,
-    handlePressOut,
-    cancel,
+    isRecording,
+    startListening,
+    stopAndUpload,
+    cancelListening,
   };
 }

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
@@ -1,92 +1,155 @@
-import {
-  RecordingPresets,
-  setAudioModeAsync,
-  useAudioRecorder,
-  useAudioRecorderState,
-} from "expo-audio";
-import { useRef } from "react";
+import { RecordingPresets, setAudioModeAsync, useAudioRecorder } from "expo-audio";
+import { useRef, useState } from "react";
 import { File as ExpoFile } from "expo-file-system";
 import { useTranslation } from "react-i18next";
 import Toast from "react-native-toast-message";
 import { analytics } from "@/shared/services/analytics";
 
-export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => Promise<void>) {
+export type VoiceInputState = "idle" | "preparing" | "recording" | "stopping" | "sending" | "error";
+
+type UseVoiceInputOptions = {
+  submitAudio: (uri: string) => Promise<void>;
+  canSubmit: boolean;
+};
+
+export function useVoiceInput({ submitAudio, canSubmit }: UseVoiceInputOptions) {
   const { t } = useTranslation("aiTaskGenerate");
   const recorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);
-  const { isRecording } = useAudioRecorderState(recorder);
-  // Prevents race condition between startListening and cancelListening.
-  const cancelRequested = useRef(false);
+  const [state, setState] = useState<VoiceInputState>("idle");
+  const [isHoldHintVisible, setIsHoldHintVisible] = useState(false);
+  const stateRef = useRef<VoiceInputState>("idle");
+  const startPromiseRef = useRef<Promise<void> | null>(null);
+  const pressActiveRef = useRef(false);
+  const recordingStartedRef = useRef(false);
 
-  const startListening = async () => {
-    cancelRequested.current = false;
+  const setVoiceState = (nextState: VoiceInputState) => {
+    stateRef.current = nextState;
+    setState(nextState);
+  };
+
+  const trackRecordingFailure = (errorCode: string) => {
+    analytics.trackAiTaskGenerationFailed({
+      inputMode: "voice",
+      stage: "recording",
+      errorCode,
+    });
+  };
+
+  const handlePressIn = () => {
+    setIsHoldHintVisible(false);
+    if (stateRef.current !== "idle" && stateRef.current !== "error") return;
+
+    if (!canSubmit) {
+      setVoiceState("error");
+      Toast.show({ type: "error", text1: t("errors.default") });
+      analytics.trackAiTaskGenerationFailed({
+        inputMode: "voice",
+        stage: "send",
+        errorCode: "ConnectionNotReady",
+      });
+      return;
+    }
+
+    pressActiveRef.current = true;
+    recordingStartedRef.current = false;
+    setVoiceState("preparing");
+
+    const startPromise = startRecording();
+    startPromiseRef.current = startPromise;
+  };
+
+  const startRecording = async (): Promise<void> => {
     try {
       await setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true });
       await recorder.prepareToRecordAsync();
-      if (cancelRequested.current) return;
+      if (!pressActiveRef.current) {
+        setVoiceState("idle");
+        return;
+      }
       recorder.record();
+      recordingStartedRef.current = true;
+      setVoiceState("recording");
     } catch (error) {
+      setVoiceState("error");
       Toast.show({ type: "error", text1: t("errors.recordingFailed") });
       console.warn("[Mic] Error starting recording.", error);
-      analytics.trackAiTaskGenerationFailed({
-        inputMode: "voice",
-        stage: "recording",
-        errorCode: "RecordingStartFailed",
-      });
+      trackRecordingFailure("RecordingStartFailed");
+    } finally {
+      startPromiseRef.current = null;
     }
   };
 
-  const cancelListening = async (): Promise<void> => {
-    cancelRequested.current = true;
-    if (recorder.isRecording) {
-      await recorder.stop();
+  const cancel = async (): Promise<void> => {
+    pressActiveRef.current = false;
+    await startPromiseRef.current;
+
+    if (recordingStartedRef.current) {
+      try {
+        await recorder.stop();
+      } catch (error) {
+        console.warn("[Mic] Error cancelling recording.", error);
+        trackRecordingFailure("RecordingCancelFailed");
+      }
     }
+
+    recordingStartedRef.current = false;
+    startPromiseRef.current = null;
+    setVoiceState("idle");
   };
 
-  const stopAndUpload = async (): Promise<void> => {
-    if (!recorder.isRecording) {
-      Toast.show({ type: "error", text1: t("errors.emptyAudio") });
-      console.warn("[Mic] stopAndUpload called but recorder is not recording.");
-      analytics.trackAiTaskGenerationFailed({
-        inputMode: "voice",
-        stage: "recording",
-        errorCode: "NotRecording",
-      });
-      return;
+  const handlePressOut = async (): Promise<boolean> => {
+    if (stateRef.current === "error" && !pressActiveRef.current && !recordingStartedRef.current) {
+      return false;
     }
 
+    pressActiveRef.current = false;
+    await startPromiseRef.current;
+
+    if (stateRef.current === "error") {
+      return false;
+    }
+
+    if (!recordingStartedRef.current) {
+      startPromiseRef.current = null;
+      setIsHoldHintVisible(true);
+      setVoiceState("idle");
+      return false;
+    }
+
+    setVoiceState("stopping");
     try {
       await recorder.stop();
     } catch (error) {
+      setVoiceState("error");
       console.warn("[Mic] Error stopping recording.", error);
-      analytics.trackAiTaskGenerationFailed({
-        inputMode: "voice",
-        stage: "recording",
-        errorCode: "RecordingStopFailed",
-      });
-      return;
+      trackRecordingFailure("RecordingStopFailed");
+      return false;
     }
+
+    recordingStartedRef.current = false;
+    startPromiseRef.current = null;
 
     const uri = recorder.uri;
     if (!uri) {
+      setVoiceState("error");
       Toast.show({ type: "error", text1: t("errors.emptyAudio") });
-      analytics.trackAiTaskGenerationFailed({
-        inputMode: "voice",
-        stage: "recording",
-        errorCode: "EmptyAudio",
-      });
-      return;
+      trackRecordingFailure("EmptyAudio");
+      return false;
     }
 
+    setVoiceState("sending");
     try {
-      await submitAudioForTranscription(uri);
+      await submitAudio(uri);
+      setVoiceState("idle");
     } catch (error) {
+      setVoiceState("error");
       console.warn("[Mic] Error submitting audio for transcription.", error);
       analytics.trackAiTaskGenerationFailed({
         inputMode: "voice",
         stage: "send",
         errorCode: "AudioSubmitFailed",
       });
-      return;
+      return false;
     }
 
     // Best-effort cleanup of the temp recording; failure here shouldn't surface as an AI failure.
@@ -95,7 +158,18 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
     } catch (error) {
       console.warn("[Mic] Failed to delete temp recording file.", error);
     }
+
+    return true;
   };
 
-  return { isRecording, startListening, stopAndUpload, cancelListening };
+  return {
+    state,
+    isRecording: state === "recording",
+    isBusy:
+      state === "preparing" || state === "recording" || state === "stopping" || state === "sending",
+    isHoldHintVisible,
+    handlePressIn,
+    handlePressOut,
+    cancel,
+  };
 }

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
@@ -7,12 +7,13 @@ import { analytics } from "@/shared/services/analytics";
 
 export type VoiceInputState = "idle" | "preparing" | "recording" | "stopping" | "sending" | "error";
 
+const CONNECTION_NOT_READY_ERROR_CODE = "ConnectionNotReady";
+
 type UseVoiceInputOptions = {
   submitAudio: (uri: string) => Promise<void>;
-  canSubmit: boolean;
 };
 
-export function useVoiceInput({ submitAudio, canSubmit }: UseVoiceInputOptions) {
+export function useVoiceInput({ submitAudio }: UseVoiceInputOptions) {
   const { t } = useTranslation("aiTaskGenerate");
   const recorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);
   const [state, setState] = useState<VoiceInputState>("idle");
@@ -38,17 +39,6 @@ export function useVoiceInput({ submitAudio, canSubmit }: UseVoiceInputOptions) 
   const handlePressIn = () => {
     setIsHoldHintVisible(false);
     if (stateRef.current !== "idle" && stateRef.current !== "error") return;
-
-    if (!canSubmit) {
-      setVoiceState("error");
-      Toast.show({ type: "error", text1: t("errors.default") });
-      analytics.trackAiTaskGenerationFailed({
-        inputMode: "voice",
-        stage: "send",
-        errorCode: "ConnectionNotReady",
-      });
-      return;
-    }
 
     pressActiveRef.current = true;
     recordingStartedRef.current = false;
@@ -144,10 +134,14 @@ export function useVoiceInput({ submitAudio, canSubmit }: UseVoiceInputOptions) 
     } catch (error) {
       setVoiceState("error");
       console.warn("[Mic] Error submitting audio for transcription.", error);
+      Toast.show({ type: "error", text1: t("errors.default") });
       analytics.trackAiTaskGenerationFailed({
         inputMode: "voice",
         stage: "send",
-        errorCode: "AudioSubmitFailed",
+        errorCode:
+          error instanceof Error && error.message === CONNECTION_NOT_READY_ERROR_CODE
+            ? CONNECTION_NOT_READY_ERROR_CODE
+            : "AudioSubmitFailed",
       });
       return false;
     }

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
@@ -47,12 +47,8 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
     }
   };
 
-  const waitForStartAfterRelease = async (): Promise<void> => {
-    await startPromiseRef.current;
-  };
-
   const cancelListening = async (): Promise<void> => {
-    await waitForStartAfterRelease();
+    await startPromiseRef.current;
 
     if (recorder.isRecording) {
       try {
@@ -65,7 +61,7 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
   };
 
   const stopAndUpload = async (): Promise<boolean> => {
-    await waitForStartAfterRelease();
+    await startPromiseRef.current;
 
     if (!recorder.isRecording) {
       Toast.show({ type: "error", text1: t("errors.emptyAudio") });

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
@@ -16,6 +16,7 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
   const { isRecording } = useAudioRecorderState(recorder);
   // Release handlers wait on this so they never race ahead of async recorder setup.
   const startPromiseRef = useRef<Promise<void> | null>(null);
+  const cancelRequested = useRef(false);
 
   const trackRecordingFailure = (errorCode: string) => {
     analytics.trackAiTaskGenerationFailed({
@@ -26,6 +27,7 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
   };
 
   const startListening = () => {
+    cancelRequested.current = false;
     const startPromise = startRecording();
     startPromiseRef.current = startPromise;
     void startPromise.finally(() => {
@@ -39,6 +41,7 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
     try {
       await setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true });
       await recorder.prepareToRecordAsync();
+      if (cancelRequested.current) return;
       recorder.record();
     } catch (error) {
       Toast.show({ type: "error", text1: t("errors.recordingFailed") });
@@ -48,6 +51,7 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
   };
 
   const cancelListening = async (): Promise<void> => {
+    cancelRequested.current = true;
     await startPromiseRef.current;
 
     if (recorder.isRecording) {
@@ -80,7 +84,6 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
 
     const uri = recorder.uri;
     if (!uri) {
-      Toast.show({ type: "error", text1: t("errors.emptyAudio") });
       trackRecordingFailure("EmptyAudio");
       return false;
     }

--- a/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
@@ -50,7 +50,6 @@ export default function AiTaskSheetScreen() {
     turns,
     streamedTasks,
     streamedNotes,
-    isConnectionReady,
     submitAudioForTranscription,
     sendTextMessage,
   } = useAiTaskGenerator({
@@ -58,6 +57,7 @@ export default function AiTaskSheetScreen() {
   });
   const { labels } = useAllLabels();
   const {
+    state: voiceInputState,
     isRecording,
     isBusy: isVoiceBusy,
     isHoldHintVisible,
@@ -65,7 +65,6 @@ export default function AiTaskSheetScreen() {
     handlePressOut: handleVoicePressOut,
   } = useVoiceInput({
     submitAudio: submitAudioForTranscription,
-    canSubmit: isConnectionReady,
   });
   const { addTaskAsync, isAdding } = useTaskMutations();
   const { createNoteAsync, isNoteCreating } = useNotesMutation();
@@ -91,6 +90,8 @@ export default function AiTaskSheetScreen() {
   );
   const displayNotes = streamedNotes;
   const hasContent = streamedTasks.length > 0 || streamedNotes.length > 0;
+  const isVoiceSubmitDisabled =
+    isAiGenerating || voiceInputState === "stopping" || voiceInputState === "sending";
 
   // --- Handlers ---
   const handleDismiss = () => {
@@ -186,7 +187,7 @@ export default function AiTaskSheetScreen() {
               {/* Task / note cards (streamed or final) */}
               {hasContent && <AiResultList aiTasks={displayTasks} aiNotes={displayNotes} />}
 
-              {!!transcript && (
+              {isAiGenerating && !!transcript && (
                 <Text className="mx-6 mb-2 text-center italic text-white/70" numberOfLines={3}>
                   &ldquo;{transcript}&rdquo;
                 </Text>
@@ -245,9 +246,9 @@ export default function AiTaskSheetScreen() {
                           backgroundColor: isRecording
                             ? "rgba(255,255,255,0.5)"
                             : "rgba(255,255,255,0.25)",
-                          opacity: isAiGenerating ? 0.4 : 1,
+                          opacity: isVoiceSubmitDisabled ? 0.4 : 1,
                         }}
-                        disabled={isAiGenerating}
+                        disabled={isVoiceSubmitDisabled}
                       >
                         {isRecording ? (
                           <LottieView

--- a/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
@@ -22,7 +22,7 @@ import { AiResultList } from "../component/ai-result-list";
 import { VoiceHintText } from "../component/voice-hint-text";
 import { ListeningIndicator } from "../component/listening-indicator";
 import { useAiTaskGenerator } from "../hooks/useAiTaskGenerator";
-import { useVoiceRecorder } from "../hooks/useVoiceRecorder";
+import { useVoiceInput } from "../hooks/useVoiceRecorder";
 import { useAllLabels } from "@/shared/hooks/useAllLabels";
 import { mapExtractedTaskDTOToAiTaskDTO } from "../utils/map-extracted-to-task-dto";
 import { convertAiTaskToTaskUpsertDTO } from "../utils/map-aitask-to-addtaskitem-dto";
@@ -43,24 +43,30 @@ export default function AiTaskSheetScreen() {
   // Interface opens in voice mode by default; the keyboard toggle switches to text.
   const [inputMode, setInputMode] = useState<"voice" | "text">("voice");
   const hasSubmittedAiRequest = useRef(false);
-  const longPressTriggered = useRef(false);
   const { isVisible: isKeyboardVisible } = useKeyboardState();
 
-  const [isHoldHintVisible, setIsHoldHintVisible] = useState(false);
   const {
     transcript,
     turns,
     streamedTasks,
     streamedNotes,
+    isConnectionReady,
     submitAudioForTranscription,
     sendTextMessage,
   } = useAiTaskGenerator({
     setIsAiGenerating,
   });
   const { labels } = useAllLabels();
-  const { isRecording, startListening, stopAndUpload, cancelListening } = useVoiceRecorder(
-    submitAudioForTranscription,
-  );
+  const {
+    isRecording,
+    isBusy: isVoiceBusy,
+    isHoldHintVisible,
+    handlePressIn: handleVoicePressIn,
+    handlePressOut: handleVoicePressOut,
+  } = useVoiceInput({
+    submitAudio: submitAudioForTranscription,
+    canSubmit: isConnectionReady,
+  });
   const { addTaskAsync, isAdding } = useTaskMutations();
   const { createNoteAsync, isNoteCreating } = useNotesMutation();
 
@@ -130,17 +136,17 @@ export default function AiTaskSheetScreen() {
   };
 
   const handleMicPressIn = () => {
-    setIsHoldHintVisible(false);
-    void startListening();
+    handleVoicePressIn();
   };
 
   const handleMicPressOut = async () => {
-    hasSubmittedAiRequest.current = true;
-    await stopAndUpload();
+    const didSubmit = await handleVoicePressOut();
+    if (didSubmit) {
+      hasSubmittedAiRequest.current = true;
+    }
   };
 
   const handleSwitchToText = () => {
-    setIsHoldHintVisible(false);
     setInputMode("text"); // TextInput autoFocus pops the keyboard on mount
   };
 
@@ -180,7 +186,7 @@ export default function AiTaskSheetScreen() {
               {/* Task / note cards (streamed or final) */}
               {hasContent && <AiResultList aiTasks={displayTasks} aiNotes={displayNotes} />}
 
-              {isAiGenerating && !!transcript && (
+              {!!transcript && (
                 <Text className="mx-6 mb-2 text-center italic text-white/70" numberOfLines={3}>
                   &ldquo;{transcript}&rdquo;
                 </Text>
@@ -212,9 +218,9 @@ export default function AiTaskSheetScreen() {
                     className="w-14 h-14 rounded-full items-center justify-center"
                     style={{
                       backgroundColor: "rgba(255,255,255,0.25)",
-                      opacity: isAiGenerating || isRecording ? 0.4 : 1,
+                      opacity: isAiGenerating || isVoiceBusy ? 0.4 : 1,
                     }}
-                    disabled={isAiGenerating || isRecording}
+                    disabled={isAiGenerating || isVoiceBusy}
                   >
                     <MaterialCommunityIcons
                       name={inputMode === "voice" ? "keyboard-outline" : "microphone"}
@@ -229,21 +235,11 @@ export default function AiTaskSheetScreen() {
                       <Pressable
                         onPressIn={() => {
                           void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-                          longPressTriggered.current = false;
                           handleMicPressIn();
                         }}
                         onPressOut={() => {
-                          if (!longPressTriggered.current) {
-                            setIsHoldHintVisible(true);
-                            cancelListening();
-                          } else {
-                            void handleMicPressOut();
-                          }
+                          void handleMicPressOut();
                         }}
-                        onLongPress={() => {
-                          longPressTriggered.current = true;
-                        }}
-                        delayLongPress={1000}
                         className="w-full h-14 rounded-full flex-row items-center justify-center gap-2"
                         style={{
                           backgroundColor: isRecording

--- a/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
@@ -22,7 +22,7 @@ import { AiResultList } from "../component/ai-result-list";
 import { VoiceHintText } from "../component/voice-hint-text";
 import { ListeningIndicator } from "../component/listening-indicator";
 import { useAiTaskGenerator } from "../hooks/useAiTaskGenerator";
-import { useVoiceInput } from "../hooks/useVoiceRecorder";
+import { useVoiceRecorder } from "../hooks/useVoiceRecorder";
 import { useAllLabels } from "@/shared/hooks/useAllLabels";
 import { mapExtractedTaskDTOToAiTaskDTO } from "../utils/map-extracted-to-task-dto";
 import { convertAiTaskToTaskUpsertDTO } from "../utils/map-aitask-to-addtaskitem-dto";
@@ -44,6 +44,7 @@ export default function AiTaskSheetScreen() {
   const [inputMode, setInputMode] = useState<"voice" | "text">("voice");
   const hasSubmittedAiRequest = useRef(false);
   const { isVisible: isKeyboardVisible } = useKeyboardState();
+  const [isHoldHintVisible, setIsHoldHintVisible] = useState(false);
 
   const {
     transcript,
@@ -56,16 +57,9 @@ export default function AiTaskSheetScreen() {
     setIsAiGenerating,
   });
   const { labels } = useAllLabels();
-  const {
-    state: voiceInputState,
-    isRecording,
-    isBusy: isVoiceBusy,
-    isHoldHintVisible,
-    handlePressIn: handleVoicePressIn,
-    handlePressOut: handleVoicePressOut,
-  } = useVoiceInput({
-    submitAudio: submitAudioForTranscription,
-  });
+  const { isRecording, startListening, stopAndUpload } = useVoiceRecorder(
+    submitAudioForTranscription,
+  );
   const { addTaskAsync, isAdding } = useTaskMutations();
   const { createNoteAsync, isNoteCreating } = useNotesMutation();
 
@@ -90,8 +84,6 @@ export default function AiTaskSheetScreen() {
   );
   const displayNotes = streamedNotes;
   const hasContent = streamedTasks.length > 0 || streamedNotes.length > 0;
-  const isVoiceSubmitDisabled =
-    isAiGenerating || voiceInputState === "stopping" || voiceInputState === "sending";
 
   // --- Handlers ---
   const handleDismiss = () => {
@@ -137,17 +129,19 @@ export default function AiTaskSheetScreen() {
   };
 
   const handleMicPressIn = () => {
-    handleVoicePressIn();
+    setIsHoldHintVisible(false);
+    void startListening();
   };
 
   const handleMicPressOut = async () => {
-    const didSubmit = await handleVoicePressOut();
+    const didSubmit = await stopAndUpload();
     if (didSubmit) {
       hasSubmittedAiRequest.current = true;
     }
   };
 
   const handleSwitchToText = () => {
+    setIsHoldHintVisible(false);
     setInputMode("text"); // TextInput autoFocus pops the keyboard on mount
   };
 
@@ -219,9 +213,9 @@ export default function AiTaskSheetScreen() {
                     className="w-14 h-14 rounded-full items-center justify-center"
                     style={{
                       backgroundColor: "rgba(255,255,255,0.25)",
-                      opacity: isAiGenerating || isVoiceBusy ? 0.4 : 1,
+                      opacity: isAiGenerating || isRecording ? 0.4 : 1,
                     }}
-                    disabled={isAiGenerating || isVoiceBusy}
+                    disabled={isAiGenerating || isRecording}
                   >
                     <MaterialCommunityIcons
                       name={inputMode === "voice" ? "keyboard-outline" : "microphone"}
@@ -246,9 +240,9 @@ export default function AiTaskSheetScreen() {
                           backgroundColor: isRecording
                             ? "rgba(255,255,255,0.5)"
                             : "rgba(255,255,255,0.25)",
-                          opacity: isVoiceSubmitDisabled ? 0.4 : 1,
+                          opacity: isAiGenerating ? 0.4 : 1,
                         }}
-                        disabled={isVoiceSubmitDisabled}
+                        disabled={isAiGenerating}
                       >
                         {isRecording ? (
                           <LottieView

--- a/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
@@ -43,6 +43,7 @@ export default function AiTaskSheetScreen() {
   // Interface opens in voice mode by default; the keyboard toggle switches to text.
   const [inputMode, setInputMode] = useState<"voice" | "text">("voice");
   const hasSubmittedAiRequest = useRef(false);
+  const longPressTriggered = useRef(false);
   const { isVisible: isKeyboardVisible } = useKeyboardState();
   const [isHoldHintVisible, setIsHoldHintVisible] = useState(false);
 
@@ -57,7 +58,7 @@ export default function AiTaskSheetScreen() {
     setIsAiGenerating,
   });
   const { labels } = useAllLabels();
-  const { isRecording, startListening, stopAndUpload } = useVoiceRecorder(
+  const { isRecording, startListening, stopAndUpload, cancelListening } = useVoiceRecorder(
     submitAudioForTranscription,
   );
   const { addTaskAsync, isAdding } = useTaskMutations();
@@ -230,11 +231,21 @@ export default function AiTaskSheetScreen() {
                       <Pressable
                         onPressIn={() => {
                           void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+                          longPressTriggered.current = false;
                           handleMicPressIn();
                         }}
                         onPressOut={() => {
-                          void handleMicPressOut();
+                          if (!longPressTriggered.current) {
+                            setIsHoldHintVisible(true);
+                            void cancelListening();
+                          } else {
+                            void handleMicPressOut();
+                          }
                         }}
+                        onLongPress={() => {
+                          longPressTriggered.current = true;
+                        }}
+                        delayLongPress={1000}
                         className="w-full h-14 rounded-full flex-row items-center justify-center gap-2"
                         style={{
                           backgroundColor: isRecording


### PR DESCRIPTION
## Summary
- Keep the original voice long-press interaction while waiting for async recorder startup before handling release
- Only mark the AI session as submitted after audio upload actually starts
- Expose the SignalR connection only after it is fully connected and guard submits by connection state

## Release note

> Voice task recording is more reliable when you release the hold-to-talk button quickly.

**Status:**

- [x] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce\n- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce\n\n## Verification\n- npx prettier --write src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts src/feature/ai-task-generate/hooks/useVoiceRecorder.ts src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx\n- npm run lint\n- git diff --check\n- npx tsc --noEmit (fails on existing unrelated react-native-calendars and subtasks-editor type errors; no errors in changed files)\n\nInternal issue: #1449