### PR TITLE
refactor: enhance task scheduling logic and descriptions for clarity

### DIFF
--- a/blotztask-api/Modules/ChatTaskGenerator/Constants/AiTaskGeneratorPrompts.cs
+++ b/blotztask-api/Modules/ChatTaskGenerator/Constants/AiTaskGeneratorPrompts.cs
@@ -7,7 +7,7 @@ public static class AiTaskGeneratorPrompts
         return $"""
                 Respond in {preferredLanguage}. The user's current local time is {userLocalTime:yyyy-MM-dd HH:mm}.
                 You maintain a running list of tasks and notes across this conversation.
-                Your ONLY job is to call tools — never reply with text alone.
+                When the user expresses tasks or notes to create, update, or remove — call the appropriate tool. Only call a tool when there is something to extract; greetings or unrelated input require no tool call.
 
                 Map every user intent to a tool call:
                 - New item with a time anchor → CreateTask (or CreateTasks for multiple)
@@ -17,11 +17,16 @@ public static class AiTaskGeneratorPrompts
 
                 Evaluate each item independently. A single message may produce both tasks and notes.
                 When no specific time is stated for a task, pick a sensible one based on context.
+                Estimate a realistic duration per task based on activity type (e.g. 30–60 min for admin tasks, 1–2 h for physical activities, 15–30 min for quick reminders).
+                When multiple tasks share the same vague time window, schedule them sequentially — start each task when the previous one ends. Never assign the same start time to more than one task.
 
                 Examples:
                 "Remind me to drink water in 10 minutes, buy groceries at 5pm, and I want to learn guitar"
                 → CreateTasks(["Drink water", "Buy groceries"], ..., [now+10min, 17:00], ...)
                 → CreateNote("Learn guitar")
+
+                "I want to modify docs, update my SOP, and go rock climbing this afternoon"
+                → CreateTasks(["Modify docs", "Update SOP", "Go rock climbing"], ..., [16:00, 17:30, 18:30], [17:30, 18:30, 20:30], ...)
 
                 "Change the gym session to 7am"
                 → UpdateTask("Gym session", ..., 07:00, ...)

--- a/blotztask-api/Modules/ChatTaskGenerator/Functions/TaskGenerationTools.cs
+++ b/blotztask-api/Modules/ChatTaskGenerator/Functions/TaskGenerationTools.cs
@@ -15,7 +15,7 @@ public class TaskGenerationTools()
 
     public void ResetCallCount() => ToolCallCount = 0;
 
-    [Description("Add multiple tasks at once. Prefer this over CreateTask when the user mentions more than one task.")]
+    [Description("Add multiple tasks at once. Prefer this over CreateTask when the user mentions more than one task. Assign sequential, non-overlapping times — estimate a realistic duration for each task and start the next where the previous ends.")]
     public async Task<string> CreateTasks(
         [Description("Array of task titles")] string[] titles,
         [Description("Array of descriptions (empty string if none)")] string[] descriptions,
@@ -110,7 +110,7 @@ public class TaskGenerationTools()
         return "Task removed.";
     }
 
-    [Description("Update a task. Use this when the user corrects or adjusts something they already said, e.g. changing the time or title of an existing task.")]
+    [Description("Update a task. Use this when the user corrects or adjusts something they already said, e.g. changing the time or title of an existing task. When updating times, ensure the result does not overlap with other tasks — adjust sequentially if needed.")]
     public string UpdateTask(
         [Description("Current title")] string existingTitle,
         [Description("New title")] string title,


### PR DESCRIPTION
## Summary

Optimise the AI prompt so tasks scheduled in the same vague time window (e.g. "this afternoon") are allocated sequentially with realistic durations instead of all receiving the same overlapping time block. Also applies the same rule to task updates.

## Release note

> When you add multiple tasks for the same general time (like "this afternoon"), the AI now schedules them one after another instead of giving them all the same time slot.

**Status:**

- [x] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce