### PR TITLE
[codex] Restore AI audio connection error message

### DIFF
--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
@@ -23,8 +23,6 @@ const ERROR_CODE_TO_I18N_KEY: Record<string, string> = {
   NoTasksExtracted: "errors.noTasksExtracted",
 };
 
-const CONNECTION_NOT_READY_ERROR_CODE = "ConnectionNotReady";
-
 export function useAiTaskGenerator({
   setIsAiGenerating,
 }: {
@@ -41,7 +39,7 @@ export function useAiTaskGenerator({
 
   const submitAudioForTranscription = async (uri: string): Promise<void> => {
     if (!connection || connection.state !== signalR.HubConnectionState.Connected) {
-      throw new Error(CONNECTION_NOT_READY_ERROR_CODE);
+      throw new Error("Cannot submit audio: not connected.");
     }
 
     const arrayBuffer = await new ExpoFile(uri).arrayBuffer();


### PR DESCRIPTION
## Summary

- Restores the original audio submission connection error message: `Cannot submit audio: not connected.`
- Removes the temporary `ConnectionNotReady` error code constant from `useAiTaskGenerator`.

## Release note

> none

**Status:**

- [ ] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [x] Internal only (refactor / infra / tests / CI / deps) — don't announce

## Why

PR #449 introduced a distinct connection-not-ready error code for the voice submission guard. This follow-up reverts that error text to the original message while keeping the existing connection readiness guard intact.

## Validation

- `npm --prefix blotztask-mobile run lint` (passes with existing warnings only)
