### PR TITLE
Create get badge by id endpoint

### DIFF
--- a/blotztask-api/Modules/Badges/Controllers/BadgeController.cs
+++ b/blotztask-api/Modules/Badges/Controllers/BadgeController.cs
@@ -7,7 +7,10 @@ namespace BlotzTask.Modules.Badges.Controllers;
 [ApiController]
 [Route("/api/[controller]")]
 [Authorize]
-public class BadgeController(GetUserBadgesQueryHandler getUserBadgesQueryHandler) : ControllerBase
+public class BadgeController(
+    GetUserBadgesQueryHandler getUserBadgesQueryHandler,
+    GetBadgeByIdQueryHandler getBadgeByIdQueryHandler) : ControllerBase
+
 {
     [HttpGet]
     public async Task<List<BadgeDto>> GetUserBadges(CancellationToken ct)
@@ -18,4 +21,15 @@ public class BadgeController(GetUserBadgesQueryHandler getUserBadgesQueryHandler
         var query = new GetUserBadgesQuery { UserId = userId };
         return await getUserBadgesQueryHandler.Handle(query, ct);
     }
+
+    [HttpGet("{id}")]
+    public async Task<BadgeByIdItemDto> GetBadgeById(int id, CancellationToken ct)
+    {
+        if (!HttpContext.Items.TryGetValue("UserId", out var userIdObj) || userIdObj is not Guid userId)
+            throw new UnauthorizedAccessException("Could not find valid user id from Http Context");
+
+        var query = new GetBadgeByIdQuery { BadgeId = id, UserId = userId };
+        return await getBadgeByIdQueryHandler.Handle(query, ct);
+    }
 }
+

--- a/blotztask-api/Modules/Badges/DependencyInjection.cs
+++ b/blotztask-api/Modules/Badges/DependencyInjection.cs
@@ -12,6 +12,7 @@ public static class DependencyInjection
         services.AddScoped<AwardNewBadgesToUserHandler>();
         services.AddScoped<GetUserBadgesQueryHandler>();
         services.AddScoped<BadgeAwardService>();
+        services.AddScoped<GetBadgeByIdQueryHandler>();
 
         services.AddHttpClient("Expo", client =>
         {

--- a/blotztask-api/Modules/Badges/Queries/GetBadgeById.cs
+++ b/blotztask-api/Modules/Badges/Queries/GetBadgeById.cs
@@ -1,0 +1,46 @@
+using BlotzTask.Infrastructure.Data;
+using BlotzTask.Modules.Users.Enums;
+using Microsoft.EntityFrameworkCore;
+using BlotzTask.Shared.Exceptions;
+
+namespace BlotzTask.Modules.Badges.Queries;
+
+public class GetBadgeByIdQuery
+{
+    public required Guid UserId { get; init; }
+    public required int BadgeId { get; init; }
+}
+
+public class GetBadgeByIdQueryHandler(BlotzTaskDbContext db, ILogger<GetBadgeByIdQueryHandler> logger)
+{
+    public async Task<BadgeByIdItemDto> Handle(GetBadgeByIdQuery query, CancellationToken ct = default)
+    {
+        logger.LogInformation("Fetching badges for UserId {UserId}", query.UserId);
+
+        var preference = await db.UserPreferences.FindAsync(query.UserId, ct);
+        var language = preference?.PreferredLanguage ?? Language.En;
+        var badge = await db.Badges.FindAsync(query.BadgeId, ct);
+
+        if (badge == null)
+            throw new NotFoundException($"Badge with ID {query.BadgeId} not found.");
+
+
+        return new BadgeByIdItemDto
+        {
+            Id = badge.Id,
+            Title = language == Language.Zh ? badge.NameZh : badge.NameEn,
+            Description = language == Language.Zh ? badge.DescriptionZh : badge.DescriptionEn,
+            IconUrl = badge.IconUrl,
+            Category = badge.Category.ToString(),
+        };
+    }
+}
+
+public class BadgeByIdItemDto
+{
+    public int Id { get; set; }
+    public required string Title { get; set; }      
+    public required string Description { get; set; }
+    public required string IconUrl { get; set; }
+    public required string Category { get; set; }
+}

--- a/blotztask-mobile/src/feature/badge/models/badge-by-id-dto.ts
+++ b/blotztask-mobile/src/feature/badge/models/badge-by-id-dto.ts
@@ -1,4 +1,4 @@
-export interface BadgedDetailDTO {
+export interface BadgeDetailDTO {
   id: number;
   title: string;
   iconUrl: string;

--- a/blotztask-mobile/src/feature/badge/models/badge-by-id-dto.ts
+++ b/blotztask-mobile/src/feature/badge/models/badge-by-id-dto.ts
@@ -1,0 +1,7 @@
+export interface BadgedDetailDTO {
+  id: number;
+  title: string;
+  iconUrl: string;
+  category: string;
+  description: string;
+}

--- a/blotztask-mobile/src/feature/badge/screens/badge-wall-screen.tsx
+++ b/blotztask-mobile/src/feature/badge/screens/badge-wall-screen.tsx
@@ -6,9 +6,6 @@ import { useBadgesQuery } from "../hooks/useBadgesQuery";
 import { BadgeCard } from "../components/badge-card";
 import { BadgeDTO } from "../models/badge-preview-dto";
 
-import { useEffect } from "react";
-import { apiClient } from "@/shared/services/api/client"; // 临时测试用
-
 const NUM_COLUMNS = 3;
 
 // `badge: null` is an invisible spacer that keeps the last row's cards at 1/3
@@ -21,14 +18,6 @@ interface BadgeGridItem {
 export default function BadgeWallScreen() {
   const { t } = useTranslation("badge");
   const { badges } = useBadgesQuery();
-
-  // 临时测试用,验证完删掉
-  useEffect(() => {
-    (async () => {
-      const res = await apiClient.get("/Badge/999"); // 3 = 慢即是快
-      console.log("badge detail:", res);
-    })();
-  }, []);
 
   const gridItems: BadgeGridItem[] = [...badges]
     .sort((a, b) => a.displayOrder - b.displayOrder)

--- a/blotztask-mobile/src/feature/badge/screens/badge-wall-screen.tsx
+++ b/blotztask-mobile/src/feature/badge/screens/badge-wall-screen.tsx
@@ -6,6 +6,9 @@ import { useBadgesQuery } from "../hooks/useBadgesQuery";
 import { BadgeCard } from "../components/badge-card";
 import { BadgeDTO } from "../models/badge-preview-dto";
 
+import { useEffect } from "react";
+import { apiClient } from "@/shared/services/api/client"; // 临时测试用
+
 const NUM_COLUMNS = 3;
 
 // `badge: null` is an invisible spacer that keeps the last row's cards at 1/3
@@ -18,6 +21,14 @@ interface BadgeGridItem {
 export default function BadgeWallScreen() {
   const { t } = useTranslation("badge");
   const { badges } = useBadgesQuery();
+
+  // 临时测试用,验证完删掉
+  useEffect(() => {
+    (async () => {
+      const res = await apiClient.get("/Badge/999"); // 3 = 慢即是快
+      console.log("badge detail:", res);
+    })();
+  }, []);
 
   const gridItems: BadgeGridItem[] = [...badges]
     .sort((a, b) => a.displayOrder - b.displayOrder)


### PR DESCRIPTION
## Summary

Add a new backend endpoint that returns a single badge's
details, localized to the user's language preference (defaults to English), and returns 404 for non-existent
badge IDs. Not yet consumed by any user-facing UI.

## Release note

none
>  "none"_

**Status:**

- [ ] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [x] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce
