### PR TITLE
[codex] Add backend support for persistent notes

### DIFF
--- a/blotztask-api/Infrastructure/Data/Configurations/NoteConfiguration.cs
+++ b/blotztask-api/Infrastructure/Data/Configurations/NoteConfiguration.cs
@@ -17,6 +17,9 @@ public class NoteConfiguration : IEntityTypeConfiguration<Note>
                      .IsRequired();
               builder.Property(n => n.UpdatedAt)
                      .IsRequired();
+              builder.Property(n => n.IsPersistent)
+                     .IsRequired()
+                     .HasDefaultValue(false);
               builder.Property(n => n.UserId)
                      .IsRequired();
               builder.HasIndex(n => n.UserId);
@@ -30,5 +33,3 @@ public class NoteConfiguration : IEntityTypeConfiguration<Note>
 
        }
 }
-
-

--- a/blotztask-api/Modules/Notes/Commands/ConvertNoteToTask.cs
+++ b/blotztask-api/Modules/Notes/Commands/ConvertNoteToTask.cs
@@ -86,9 +86,11 @@ public class ConvertNoteToTaskCommandHandler(
         db.TaskItems.Add(newTask);
         await db.SaveChangesAsync(ct);
         
-        // 4. delete original note
-        db.Notes.Remove(note);
-        await db.SaveChangesAsync(ct);
+        if (!note.IsPersistent)
+        {
+            db.Notes.Remove(note);
+            await db.SaveChangesAsync(ct);
+        }
         
         await transaction.CommitAsync(ct);
         

--- a/blotztask-api/Modules/Notes/Commands/CreateNote.cs
+++ b/blotztask-api/Modules/Notes/Commands/CreateNote.cs
@@ -9,6 +9,7 @@ public class CreateNoteCommand
 {
   [Required] public Guid UserId { get; set; }
   [Required] public string Text { get; set; } = string.Empty;
+  public bool IsPersistent { get; set; }
 }
 public class CreateNoteCommandHandler(BlotzTaskDbContext db, ILogger<CreateNoteCommandHandler> logger)
 {
@@ -25,6 +26,7 @@ public class CreateNoteCommandHandler(BlotzTaskDbContext db, ILogger<CreateNoteC
     {
       Id = Guid.NewGuid(),
       Text = text,
+      IsPersistent = command.IsPersistent,
       CreatedAt = utcNow,
       UpdatedAt = utcNow,
       UserId = command.UserId
@@ -38,6 +40,7 @@ public class CreateNoteCommandHandler(BlotzTaskDbContext db, ILogger<CreateNoteC
       Text = note.Text,
       CreatedAt = note.CreatedAt,
       UpdatedAt = note.UpdatedAt,
+      IsPersistent = note.IsPersistent
     };
   }
 

--- a/blotztask-api/Modules/Notes/Commands/UpdateNote.cs
+++ b/blotztask-api/Modules/Notes/Commands/UpdateNote.cs
@@ -13,6 +13,7 @@ public class UpdateNoteCommand
   [Required] public required Guid NoteId { get; set; }
   [Required] public required string Text { get; set; }
   [Required] public required Guid UserId { get; set; }
+  public bool IsPersistent { get; set; }
 
 }
 public class UpdateNoteCommandHandler(BlotzTaskDbContext db, ILogger<UpdateNoteCommandHandler> logger)
@@ -30,6 +31,7 @@ public class UpdateNoteCommandHandler(BlotzTaskDbContext db, ILogger<UpdateNoteC
     if (text.Length > 2000)
       throw new ArgumentException("Text max length is 2000");
     note.Text = text;
+    note.IsPersistent = command.IsPersistent;
     note.UpdatedAt = DateTime.UtcNow;
     await db.SaveChangesAsync(ct);
     return new NoteDto
@@ -37,7 +39,8 @@ public class UpdateNoteCommandHandler(BlotzTaskDbContext db, ILogger<UpdateNoteC
       Id = note.Id,
       Text = note.Text,
       CreatedAt = note.CreatedAt,
-      UpdatedAt = note.UpdatedAt
+      UpdatedAt = note.UpdatedAt,
+      IsPersistent = note.IsPersistent
     };
   }
 }

--- a/blotztask-api/Modules/Notes/Controllers/NotesController.cs
+++ b/blotztask-api/Modules/Notes/Controllers/NotesController.cs
@@ -26,7 +26,8 @@ public class NotesController(
         var command = new CreateNoteCommand
         {
             UserId = userId,
-            Text = request.Text
+            Text = request.Text,
+            IsPersistent = request.IsPersistent
         };
         return await createNoteCommandHandler.Handle(command, ct);
     }
@@ -65,7 +66,8 @@ public class NotesController(
         {
             NoteId = id,
             UserId = userId,
-            Text = dto.Text
+            Text = dto.Text,
+            IsPersistent = dto.IsPersistent
         };
         return await updateNoteCommandHandler.Handle(command, ct);
     }

--- a/blotztask-api/Modules/Notes/DTOs/NoteDto.cs
+++ b/blotztask-api/Modules/Notes/DTOs/NoteDto.cs
@@ -6,5 +6,6 @@ public class NoteDto
   public string Text { get; set; }
   public DateTime CreatedAt { get; set; }
   public DateTime UpdatedAt { get; set; }
+  public bool IsPersistent { get; set; }
 
 }

--- a/blotztask-api/Modules/Notes/DTOs/NoteRequestDto.cs
+++ b/blotztask-api/Modules/Notes/DTOs/NoteRequestDto.cs
@@ -5,4 +5,5 @@ namespace BlotzTask.Modules.Notes.DTOs;
 public class NoteRequestDto
 {
   [Required] public string Text { get; set; } = string.Empty;
+  public bool IsPersistent { get; set; }
 }

--- a/blotztask-api/Modules/Notes/Domain/Note.cs
+++ b/blotztask-api/Modules/Notes/Domain/Note.cs
@@ -11,6 +11,7 @@ public class Note
   public string Text { get; set; } = string.Empty;
   public DateTime CreatedAt { get; set; }
   public DateTime UpdatedAt { get; set; }
+  public bool IsPersistent { get; set; }
   public Guid UserId { get; set; }
   public AppUser? User { get; set; }
 

--- a/blotztask-api/Modules/Notes/Queries/SearchNotes.cs
+++ b/blotztask-api/Modules/Notes/Queries/SearchNotes.cs
@@ -31,7 +31,8 @@ public class SearchNotesQueryHandler(BlotzTaskDbContext db, ILogger<SearchNotesQ
                         Id = n.Id,
                         Text = n.Text,
                         CreatedAt = n.CreatedAt,
-                        UpdatedAt = n.UpdatedAt
+                        UpdatedAt = n.UpdatedAt,
+                        IsPersistent = n.IsPersistent
                       })
                       .ToListAsync(ct);
 


### PR DESCRIPTION
## Summary

Adds backend support for persistent Notes. Persistent Notes can now be created, updated, listed, and converted to Tasks without deleting the original Note. Normal Notes keep the existing one-time conversion behavior.

## Changes

- Add `IsPersistent` to the Note entity and EF configuration with default `false`.
- Accept `isPersistent` in note create/update requests.
- Return `isPersistent` in Note DTOs and search/list responses.
- Keep persistent Notes when converting to Tasks; delete normal Notes as before.

## Migration

This requires an EF migration from `blotztask-api/`:

```bash
dotnet ef migrations add AddIsPersistentToNotes
dotnet ef database update
```

## Validation

- `dotnet build blotztask-api/BlotzTask.csproj --no-restore`

Tests were intentionally removed per follow-up request.