### PR TITLE
Add backend support for persistent notes

### DIFF
--- a/blotztask-api/Infrastructure/Data/Configurations/NoteConfiguration.cs
+++ b/blotztask-api/Infrastructure/Data/Configurations/NoteConfiguration.cs
@@ -17,6 +17,9 @@ public class NoteConfiguration : IEntityTypeConfiguration<Note>
                      .IsRequired();
               builder.Property(n => n.UpdatedAt)
                      .IsRequired();
+              builder.Property(n => n.IsPersistent)
+                     .IsRequired()
+                     .HasDefaultValue(false);
               builder.Property(n => n.UserId)
                      .IsRequired();
               builder.HasIndex(n => n.UserId);
@@ -30,5 +33,3 @@ public class NoteConfiguration : IEntityTypeConfiguration<Note>
 
        }
 }
-
-

--- a/blotztask-api/Infrastructure/Data/Migrations/20260703044411_AddIsPersistentToNotes.Designer.cs
+++ b/blotztask-api/Infrastructure/Data/Migrations/20260703044411_AddIsPersistentToNotes.Designer.cs
@@ -4,16 +4,19 @@ using BlotzTask.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace BlotzTask.Migrations
+namespace BlotzTask.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(BlotzTaskDbContext))]
-    partial class BlotzTaskDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260703044411_AddIsPersistentToNotes")]
+    partial class AddIsPersistentToNotes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/blotztask-api/Infrastructure/Data/Migrations/20260703044411_AddIsPersistentToNotes.cs
+++ b/blotztask-api/Infrastructure/Data/Migrations/20260703044411_AddIsPersistentToNotes.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BlotzTask.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsPersistentToNotes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsPersistent",
+                table: "Notes",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsPersistent",
+                table: "Notes");
+        }
+    }
+}

--- a/blotztask-api/Modules/Notes/Commands/ConvertNoteToTask.cs
+++ b/blotztask-api/Modules/Notes/Commands/ConvertNoteToTask.cs
@@ -86,9 +86,11 @@ public class ConvertNoteToTaskCommandHandler(
         db.TaskItems.Add(newTask);
         await db.SaveChangesAsync(ct);
         
-        // 4. delete original note
-        db.Notes.Remove(note);
-        await db.SaveChangesAsync(ct);
+        if (!note.IsPersistent)
+        {
+            db.Notes.Remove(note);
+            await db.SaveChangesAsync(ct);
+        }
         
         await transaction.CommitAsync(ct);
         

--- a/blotztask-api/Modules/Notes/Commands/CreateNote.cs
+++ b/blotztask-api/Modules/Notes/Commands/CreateNote.cs
@@ -9,7 +9,7 @@ public class CreateNoteCommand
 {
   [Required] public Guid UserId { get; set; }
   [Required] public string Text { get; set; } = string.Empty;
-  public bool IsPersistent { get; set; }
+  [Required] public bool IsPersistent { get; set; }
 }
 public class CreateNoteCommandHandler(BlotzTaskDbContext db, ILogger<CreateNoteCommandHandler> logger)
 {

--- a/blotztask-api/Modules/Notes/Commands/CreateNote.cs
+++ b/blotztask-api/Modules/Notes/Commands/CreateNote.cs
@@ -9,7 +9,7 @@ public class CreateNoteCommand
 {
   [Required] public Guid UserId { get; set; }
   [Required] public string Text { get; set; } = string.Empty;
-  [Required] public bool IsPersistent { get; set; }
+  public bool? IsPersistent { get; set; }
 }
 public class CreateNoteCommandHandler(BlotzTaskDbContext db, ILogger<CreateNoteCommandHandler> logger)
 {
@@ -26,7 +26,7 @@ public class CreateNoteCommandHandler(BlotzTaskDbContext db, ILogger<CreateNoteC
     {
       Id = Guid.NewGuid(),
       Text = text,
-      IsPersistent = command.IsPersistent,
+      IsPersistent = command.IsPersistent ?? false,
       CreatedAt = utcNow,
       UpdatedAt = utcNow,
       UserId = command.UserId

--- a/blotztask-api/Modules/Notes/Commands/CreateNote.cs
+++ b/blotztask-api/Modules/Notes/Commands/CreateNote.cs
@@ -9,6 +9,7 @@ public class CreateNoteCommand
 {
   [Required] public Guid UserId { get; set; }
   [Required] public string Text { get; set; } = string.Empty;
+  public bool IsPersistent { get; set; }
 }
 public class CreateNoteCommandHandler(BlotzTaskDbContext db, ILogger<CreateNoteCommandHandler> logger)
 {
@@ -25,6 +26,7 @@ public class CreateNoteCommandHandler(BlotzTaskDbContext db, ILogger<CreateNoteC
     {
       Id = Guid.NewGuid(),
       Text = text,
+      IsPersistent = command.IsPersistent,
       CreatedAt = utcNow,
       UpdatedAt = utcNow,
       UserId = command.UserId
@@ -38,6 +40,7 @@ public class CreateNoteCommandHandler(BlotzTaskDbContext db, ILogger<CreateNoteC
       Text = note.Text,
       CreatedAt = note.CreatedAt,
       UpdatedAt = note.UpdatedAt,
+      IsPersistent = note.IsPersistent
     };
   }
 

--- a/blotztask-api/Modules/Notes/Commands/UpdateNote.cs
+++ b/blotztask-api/Modules/Notes/Commands/UpdateNote.cs
@@ -13,7 +13,7 @@ public class UpdateNoteCommand
   [Required] public required Guid NoteId { get; set; }
   [Required] public required string Text { get; set; }
   [Required] public required Guid UserId { get; set; }
-  public bool IsPersistent { get; set; }
+  [Required] public bool IsPersistent { get; set; }
 
 }
 public class UpdateNoteCommandHandler(BlotzTaskDbContext db, ILogger<UpdateNoteCommandHandler> logger)

--- a/blotztask-api/Modules/Notes/Commands/UpdateNote.cs
+++ b/blotztask-api/Modules/Notes/Commands/UpdateNote.cs
@@ -13,7 +13,7 @@ public class UpdateNoteCommand
   [Required] public required Guid NoteId { get; set; }
   [Required] public required string Text { get; set; }
   [Required] public required Guid UserId { get; set; }
-  [Required] public required bool IsPersistent { get; set; }
+  public bool? IsPersistent { get; set; }
 
 }
 public class UpdateNoteCommandHandler(BlotzTaskDbContext db, ILogger<UpdateNoteCommandHandler> logger)
@@ -31,7 +31,7 @@ public class UpdateNoteCommandHandler(BlotzTaskDbContext db, ILogger<UpdateNoteC
     if (text.Length > 2000)
       throw new ArgumentException("Text max length is 2000");
     note.Text = text;
-    note.IsPersistent = command.IsPersistent;
+    note.IsPersistent = command.IsPersistent ?? note.IsPersistent;
     note.UpdatedAt = DateTime.UtcNow;
     await db.SaveChangesAsync(ct);
     return new NoteDto

--- a/blotztask-api/Modules/Notes/Commands/UpdateNote.cs
+++ b/blotztask-api/Modules/Notes/Commands/UpdateNote.cs
@@ -13,6 +13,7 @@ public class UpdateNoteCommand
   [Required] public required Guid NoteId { get; set; }
   [Required] public required string Text { get; set; }
   [Required] public required Guid UserId { get; set; }
+  public bool IsPersistent { get; set; }
 
 }
 public class UpdateNoteCommandHandler(BlotzTaskDbContext db, ILogger<UpdateNoteCommandHandler> logger)
@@ -30,6 +31,7 @@ public class UpdateNoteCommandHandler(BlotzTaskDbContext db, ILogger<UpdateNoteC
     if (text.Length > 2000)
       throw new ArgumentException("Text max length is 2000");
     note.Text = text;
+    note.IsPersistent = command.IsPersistent;
     note.UpdatedAt = DateTime.UtcNow;
     await db.SaveChangesAsync(ct);
     return new NoteDto
@@ -37,7 +39,8 @@ public class UpdateNoteCommandHandler(BlotzTaskDbContext db, ILogger<UpdateNoteC
       Id = note.Id,
       Text = note.Text,
       CreatedAt = note.CreatedAt,
-      UpdatedAt = note.UpdatedAt
+      UpdatedAt = note.UpdatedAt,
+      IsPersistent = note.IsPersistent
     };
   }
 }

--- a/blotztask-api/Modules/Notes/Commands/UpdateNote.cs
+++ b/blotztask-api/Modules/Notes/Commands/UpdateNote.cs
@@ -13,7 +13,7 @@ public class UpdateNoteCommand
   [Required] public required Guid NoteId { get; set; }
   [Required] public required string Text { get; set; }
   [Required] public required Guid UserId { get; set; }
-  [Required] public bool IsPersistent { get; set; }
+  [Required] public required bool IsPersistent { get; set; }
 
 }
 public class UpdateNoteCommandHandler(BlotzTaskDbContext db, ILogger<UpdateNoteCommandHandler> logger)

--- a/blotztask-api/Modules/Notes/Controllers/NotesController.cs
+++ b/blotztask-api/Modules/Notes/Controllers/NotesController.cs
@@ -26,7 +26,8 @@ public class NotesController(
         var command = new CreateNoteCommand
         {
             UserId = userId,
-            Text = request.Text
+            Text = request.Text,
+            IsPersistent = request.IsPersistent
         };
         return await createNoteCommandHandler.Handle(command, ct);
     }
@@ -65,7 +66,8 @@ public class NotesController(
         {
             NoteId = id,
             UserId = userId,
-            Text = dto.Text
+            Text = dto.Text,
+            IsPersistent = dto.IsPersistent
         };
         return await updateNoteCommandHandler.Handle(command, ct);
     }

--- a/blotztask-api/Modules/Notes/Controllers/NotesController.cs
+++ b/blotztask-api/Modules/Notes/Controllers/NotesController.cs
@@ -27,7 +27,7 @@ public class NotesController(
         {
             UserId = userId,
             Text = request.Text,
-            IsPersistent = request.IsPersistent ?? false
+            IsPersistent = request.IsPersistent
         };
         return await createNoteCommandHandler.Handle(command, ct);
     }

--- a/blotztask-api/Modules/Notes/Controllers/NotesController.cs
+++ b/blotztask-api/Modules/Notes/Controllers/NotesController.cs
@@ -27,7 +27,7 @@ public class NotesController(
         {
             UserId = userId,
             Text = request.Text,
-            IsPersistent = request.IsPersistent
+            IsPersistent = request.IsPersistent ?? false
         };
         return await createNoteCommandHandler.Handle(command, ct);
     }

--- a/blotztask-api/Modules/Notes/DTOs/NoteDto.cs
+++ b/blotztask-api/Modules/Notes/DTOs/NoteDto.cs
@@ -6,5 +6,6 @@ public class NoteDto
   public string Text { get; set; }
   public DateTime CreatedAt { get; set; }
   public DateTime UpdatedAt { get; set; }
+  public bool IsPersistent { get; set; }
 
 }

--- a/blotztask-api/Modules/Notes/DTOs/NoteRequestDto.cs
+++ b/blotztask-api/Modules/Notes/DTOs/NoteRequestDto.cs
@@ -5,5 +5,5 @@ namespace BlotzTask.Modules.Notes.DTOs;
 public class NoteRequestDto
 {
   [Required] public string Text { get; set; } = string.Empty;
-  [Required] public bool IsPersistent { get; set; }
+  public bool? IsPersistent { get; set; }
 }

--- a/blotztask-api/Modules/Notes/DTOs/NoteRequestDto.cs
+++ b/blotztask-api/Modules/Notes/DTOs/NoteRequestDto.cs
@@ -5,4 +5,5 @@ namespace BlotzTask.Modules.Notes.DTOs;
 public class NoteRequestDto
 {
   [Required] public string Text { get; set; } = string.Empty;
+  public bool IsPersistent { get; set; }
 }

--- a/blotztask-api/Modules/Notes/DTOs/NoteRequestDto.cs
+++ b/blotztask-api/Modules/Notes/DTOs/NoteRequestDto.cs
@@ -5,5 +5,5 @@ namespace BlotzTask.Modules.Notes.DTOs;
 public class NoteRequestDto
 {
   [Required] public string Text { get; set; } = string.Empty;
-  public bool IsPersistent { get; set; }
+  [Required] public bool IsPersistent { get; set; }
 }

--- a/blotztask-api/Modules/Notes/Domain/Note.cs
+++ b/blotztask-api/Modules/Notes/Domain/Note.cs
@@ -11,6 +11,7 @@ public class Note
   public string Text { get; set; } = string.Empty;
   public DateTime CreatedAt { get; set; }
   public DateTime UpdatedAt { get; set; }
+  public bool IsPersistent { get; set; }
   public Guid UserId { get; set; }
   public AppUser? User { get; set; }
 

--- a/blotztask-api/Modules/Notes/Queries/SearchNotes.cs
+++ b/blotztask-api/Modules/Notes/Queries/SearchNotes.cs
@@ -31,7 +31,8 @@ public class SearchNotesQueryHandler(BlotzTaskDbContext db, ILogger<SearchNotesQ
                         Id = n.Id,
                         Text = n.Text,
                         CreatedAt = n.CreatedAt,
-                        UpdatedAt = n.UpdatedAt
+                        UpdatedAt = n.UpdatedAt,
+                        IsPersistent = n.IsPersistent
                       })
                       .ToListAsync(ct);
 

--- a/blotztask-api/Modules/Users/Services/DefaultOnboardingData.cs
+++ b/blotztask-api/Modules/Users/Services/DefaultOnboardingData.cs
@@ -93,6 +93,7 @@ public static class DefaultOnboardingData
                 {
                     Text = "欢迎使用 BlotzTask！这是你的第一条笔记。",
                     UserId = userId,
+                    IsPersistent = true,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 },
@@ -100,6 +101,7 @@ public static class DefaultOnboardingData
                 {
                     Text = "你可以用笔记快速记录想法和灵感。",
                     UserId = userId,
+                    IsPersistent = true,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 },
@@ -107,6 +109,7 @@ public static class DefaultOnboardingData
                 {
                     Text = "笔记适合记录那些暂时不需要截止日期的事情。",
                     UserId = userId,
+                    IsPersistent = true,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 },
@@ -114,6 +117,7 @@ public static class DefaultOnboardingData
                 {
                     Text = "试着创建一条属于你的笔记吧！",
                     UserId = userId,
+                    IsPersistent = true,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 }
@@ -126,6 +130,7 @@ public static class DefaultOnboardingData
             {
                 Text = "Welcome to BlotzTask! This is your first note.",
                 UserId = userId,
+                IsPersistent = true,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             },
@@ -133,6 +138,7 @@ public static class DefaultOnboardingData
             {
                 Text = "You can use notes to capture quick thoughts and ideas.",
                 UserId = userId,
+                IsPersistent = true,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             },
@@ -140,6 +146,7 @@ public static class DefaultOnboardingData
             {
                 Text = "Notes are perfect for things that don't need a due date.",
                 UserId = userId,
+                IsPersistent = true,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             },
@@ -147,6 +154,7 @@ public static class DefaultOnboardingData
             {
                 Text = "Try creating your own note!",
                 UserId = userId,
+                IsPersistent = true,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             }

--- a/blotztask-api/Modules/Users/Services/DefaultOnboardingData.cs
+++ b/blotztask-api/Modules/Users/Services/DefaultOnboardingData.cs
@@ -93,7 +93,6 @@ public static class DefaultOnboardingData
                 {
                     Text = "欢迎使用 BlotzTask！这是你的第一条笔记。",
                     UserId = userId,
-                    IsPersistent = true,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 },
@@ -101,7 +100,6 @@ public static class DefaultOnboardingData
                 {
                     Text = "你可以用笔记快速记录想法和灵感。",
                     UserId = userId,
-                    IsPersistent = true,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 },
@@ -109,7 +107,6 @@ public static class DefaultOnboardingData
                 {
                     Text = "笔记适合记录那些暂时不需要截止日期的事情。",
                     UserId = userId,
-                    IsPersistent = true,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 },
@@ -117,7 +114,6 @@ public static class DefaultOnboardingData
                 {
                     Text = "试着创建一条属于你的笔记吧！",
                     UserId = userId,
-                    IsPersistent = true,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 }
@@ -130,7 +126,6 @@ public static class DefaultOnboardingData
             {
                 Text = "Welcome to BlotzTask! This is your first note.",
                 UserId = userId,
-                IsPersistent = true,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             },
@@ -138,7 +133,6 @@ public static class DefaultOnboardingData
             {
                 Text = "You can use notes to capture quick thoughts and ideas.",
                 UserId = userId,
-                IsPersistent = true,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             },
@@ -146,7 +140,6 @@ public static class DefaultOnboardingData
             {
                 Text = "Notes are perfect for things that don't need a due date.",
                 UserId = userId,
-                IsPersistent = true,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             },
@@ -154,7 +147,6 @@ public static class DefaultOnboardingData
             {
                 Text = "Try creating your own note!",
                 UserId = userId,
-                IsPersistent = true,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             }

--- a/blotztask-api/Modules/Users/Services/DefaultOnboardingData.cs
+++ b/blotztask-api/Modules/Users/Services/DefaultOnboardingData.cs
@@ -93,7 +93,7 @@ public static class DefaultOnboardingData
                 {
                     Text = "欢迎使用 BlotzTask！这是你的第一条笔记。",
                     UserId = userId,
-                    IsPersistent = true,
+                    IsPersistent = false,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 },
@@ -101,7 +101,7 @@ public static class DefaultOnboardingData
                 {
                     Text = "你可以用笔记快速记录想法和灵感。",
                     UserId = userId,
-                    IsPersistent = true,
+                    IsPersistent = false,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 },
@@ -109,7 +109,7 @@ public static class DefaultOnboardingData
                 {
                     Text = "笔记适合记录那些暂时不需要截止日期的事情。",
                     UserId = userId,
-                    IsPersistent = true,
+                    IsPersistent = false,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 },
@@ -117,7 +117,7 @@ public static class DefaultOnboardingData
                 {
                     Text = "试着创建一条属于你的笔记吧！",
                     UserId = userId,
-                    IsPersistent = true,
+                    IsPersistent = false,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 }
@@ -130,7 +130,7 @@ public static class DefaultOnboardingData
             {
                 Text = "Welcome to BlotzTask! This is your first note.",
                 UserId = userId,
-                IsPersistent = true,
+                IsPersistent = false,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             },
@@ -138,7 +138,7 @@ public static class DefaultOnboardingData
             {
                 Text = "You can use notes to capture quick thoughts and ideas.",
                 UserId = userId,
-                IsPersistent = true,
+                IsPersistent = false,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             },
@@ -146,7 +146,7 @@ public static class DefaultOnboardingData
             {
                 Text = "Notes are perfect for things that don't need a due date.",
                 UserId = userId,
-                IsPersistent = true,
+                IsPersistent = false,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             },
@@ -154,7 +154,7 @@ public static class DefaultOnboardingData
             {
                 Text = "Try creating your own note!",
                 UserId = userId,
-                IsPersistent = true,
+                IsPersistent = false,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             }


### PR DESCRIPTION
## Summary

Adds backend support for persistent Notes. Persistent Notes can now be created, updated, listed, and converted to Tasks without deleting the original Note. Normal Notes keep the existing one-time conversion behavior.

## Release note

> none

**Status:**

- [ ] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [x] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce

## Changes

- Add `IsPersistent` to the Note entity and EF configuration with default `false`.
- Accept `isPersistent` in note create/update requests.
- Return `isPersistent` in Note DTOs and search/list responses.
- Keep persistent Notes when converting to Tasks; delete normal Notes as before.

## Migration

This requires an EF migration from `blotztask-api/`:

```bash
dotnet ef migrations add AddIsPersistentToNotes
dotnet ef database update
```

## Validation

- `dotnet build blotztask-api/BlotzTask.csproj --no-restore`

Tests were intentionally removed per follow-up request.