### PR TITLE
[codex] Add frontend control for persistent notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,6 @@
 
 ## Code Changes
 
-- Any code change must be as minimal as possible while still solving the task.
 - Break changes into small, focused steps. Never rewrite multiple files in one go without walking the user through each change.
 - Do not run code-generation, schema-generation, or migration commands unless the relevant project-local skill explicitly allows it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 
 ## Code Changes
 
+- Any code change must be as minimal as possible while still solving the task.
 - Break changes into small, focused steps. Never rewrite multiple files in one go without walking the user through each change.
 - Do not run code-generation, schema-generation, or migration commands unless the relevant project-local skill explicitly allows it.
 

--- a/blotztask-api/Infrastructure/Data/Configurations/NoteConfiguration.cs
+++ b/blotztask-api/Infrastructure/Data/Configurations/NoteConfiguration.cs
@@ -17,6 +17,9 @@ public class NoteConfiguration : IEntityTypeConfiguration<Note>
                      .IsRequired();
               builder.Property(n => n.UpdatedAt)
                      .IsRequired();
+              builder.Property(n => n.IsPersistent)
+                     .IsRequired()
+                     .HasDefaultValue(false);
               builder.Property(n => n.UserId)
                      .IsRequired();
               builder.HasIndex(n => n.UserId);
@@ -30,5 +33,3 @@ public class NoteConfiguration : IEntityTypeConfiguration<Note>
 
        }
 }
-
-

--- a/blotztask-api/Infrastructure/Data/Migrations/20260703044411_AddIsPersistentToNotes.Designer.cs
+++ b/blotztask-api/Infrastructure/Data/Migrations/20260703044411_AddIsPersistentToNotes.Designer.cs
@@ -4,16 +4,19 @@ using BlotzTask.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace BlotzTask.Migrations
+namespace BlotzTask.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(BlotzTaskDbContext))]
-    partial class BlotzTaskDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260703044411_AddIsPersistentToNotes")]
+    partial class AddIsPersistentToNotes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/blotztask-api/Infrastructure/Data/Migrations/20260703044411_AddIsPersistentToNotes.cs
+++ b/blotztask-api/Infrastructure/Data/Migrations/20260703044411_AddIsPersistentToNotes.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BlotzTask.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsPersistentToNotes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsPersistent",
+                table: "Notes",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsPersistent",
+                table: "Notes");
+        }
+    }
+}

--- a/blotztask-api/Modules/Notes/Commands/ConvertNoteToTask.cs
+++ b/blotztask-api/Modules/Notes/Commands/ConvertNoteToTask.cs
@@ -86,9 +86,11 @@ public class ConvertNoteToTaskCommandHandler(
         db.TaskItems.Add(newTask);
         await db.SaveChangesAsync(ct);
         
-        // 4. delete original note
-        db.Notes.Remove(note);
-        await db.SaveChangesAsync(ct);
+        if (!note.IsPersistent)
+        {
+            db.Notes.Remove(note);
+            await db.SaveChangesAsync(ct);
+        }
         
         await transaction.CommitAsync(ct);
         

--- a/blotztask-api/Modules/Notes/Commands/CreateNote.cs
+++ b/blotztask-api/Modules/Notes/Commands/CreateNote.cs
@@ -9,7 +9,7 @@ public class CreateNoteCommand
 {
   [Required] public Guid UserId { get; set; }
   [Required] public string Text { get; set; } = string.Empty;
-  public bool IsPersistent { get; set; }
+  [Required] public bool IsPersistent { get; set; }
 }
 public class CreateNoteCommandHandler(BlotzTaskDbContext db, ILogger<CreateNoteCommandHandler> logger)
 {

--- a/blotztask-api/Modules/Notes/Commands/CreateNote.cs
+++ b/blotztask-api/Modules/Notes/Commands/CreateNote.cs
@@ -9,7 +9,7 @@ public class CreateNoteCommand
 {
   [Required] public Guid UserId { get; set; }
   [Required] public string Text { get; set; } = string.Empty;
-  [Required] public bool IsPersistent { get; set; }
+  public bool? IsPersistent { get; set; }
 }
 public class CreateNoteCommandHandler(BlotzTaskDbContext db, ILogger<CreateNoteCommandHandler> logger)
 {
@@ -26,7 +26,7 @@ public class CreateNoteCommandHandler(BlotzTaskDbContext db, ILogger<CreateNoteC
     {
       Id = Guid.NewGuid(),
       Text = text,
-      IsPersistent = command.IsPersistent,
+      IsPersistent = command.IsPersistent ?? false,
       CreatedAt = utcNow,
       UpdatedAt = utcNow,
       UserId = command.UserId

--- a/blotztask-api/Modules/Notes/Commands/CreateNote.cs
+++ b/blotztask-api/Modules/Notes/Commands/CreateNote.cs
@@ -9,6 +9,7 @@ public class CreateNoteCommand
 {
   [Required] public Guid UserId { get; set; }
   [Required] public string Text { get; set; } = string.Empty;
+  public bool IsPersistent { get; set; }
 }
 public class CreateNoteCommandHandler(BlotzTaskDbContext db, ILogger<CreateNoteCommandHandler> logger)
 {
@@ -25,6 +26,7 @@ public class CreateNoteCommandHandler(BlotzTaskDbContext db, ILogger<CreateNoteC
     {
       Id = Guid.NewGuid(),
       Text = text,
+      IsPersistent = command.IsPersistent,
       CreatedAt = utcNow,
       UpdatedAt = utcNow,
       UserId = command.UserId
@@ -38,6 +40,7 @@ public class CreateNoteCommandHandler(BlotzTaskDbContext db, ILogger<CreateNoteC
       Text = note.Text,
       CreatedAt = note.CreatedAt,
       UpdatedAt = note.UpdatedAt,
+      IsPersistent = note.IsPersistent
     };
   }
 

--- a/blotztask-api/Modules/Notes/Commands/UpdateNote.cs
+++ b/blotztask-api/Modules/Notes/Commands/UpdateNote.cs
@@ -13,7 +13,7 @@ public class UpdateNoteCommand
   [Required] public required Guid NoteId { get; set; }
   [Required] public required string Text { get; set; }
   [Required] public required Guid UserId { get; set; }
-  public bool IsPersistent { get; set; }
+  [Required] public bool IsPersistent { get; set; }
 
 }
 public class UpdateNoteCommandHandler(BlotzTaskDbContext db, ILogger<UpdateNoteCommandHandler> logger)

--- a/blotztask-api/Modules/Notes/Commands/UpdateNote.cs
+++ b/blotztask-api/Modules/Notes/Commands/UpdateNote.cs
@@ -13,7 +13,7 @@ public class UpdateNoteCommand
   [Required] public required Guid NoteId { get; set; }
   [Required] public required string Text { get; set; }
   [Required] public required Guid UserId { get; set; }
-  [Required] public required bool IsPersistent { get; set; }
+  public bool? IsPersistent { get; set; }
 
 }
 public class UpdateNoteCommandHandler(BlotzTaskDbContext db, ILogger<UpdateNoteCommandHandler> logger)
@@ -31,7 +31,7 @@ public class UpdateNoteCommandHandler(BlotzTaskDbContext db, ILogger<UpdateNoteC
     if (text.Length > 2000)
       throw new ArgumentException("Text max length is 2000");
     note.Text = text;
-    note.IsPersistent = command.IsPersistent;
+    note.IsPersistent = command.IsPersistent ?? note.IsPersistent;
     note.UpdatedAt = DateTime.UtcNow;
     await db.SaveChangesAsync(ct);
     return new NoteDto

--- a/blotztask-api/Modules/Notes/Commands/UpdateNote.cs
+++ b/blotztask-api/Modules/Notes/Commands/UpdateNote.cs
@@ -13,6 +13,7 @@ public class UpdateNoteCommand
   [Required] public required Guid NoteId { get; set; }
   [Required] public required string Text { get; set; }
   [Required] public required Guid UserId { get; set; }
+  public bool IsPersistent { get; set; }
 
 }
 public class UpdateNoteCommandHandler(BlotzTaskDbContext db, ILogger<UpdateNoteCommandHandler> logger)
@@ -30,6 +31,7 @@ public class UpdateNoteCommandHandler(BlotzTaskDbContext db, ILogger<UpdateNoteC
     if (text.Length > 2000)
       throw new ArgumentException("Text max length is 2000");
     note.Text = text;
+    note.IsPersistent = command.IsPersistent;
     note.UpdatedAt = DateTime.UtcNow;
     await db.SaveChangesAsync(ct);
     return new NoteDto
@@ -37,7 +39,8 @@ public class UpdateNoteCommandHandler(BlotzTaskDbContext db, ILogger<UpdateNoteC
       Id = note.Id,
       Text = note.Text,
       CreatedAt = note.CreatedAt,
-      UpdatedAt = note.UpdatedAt
+      UpdatedAt = note.UpdatedAt,
+      IsPersistent = note.IsPersistent
     };
   }
 }

--- a/blotztask-api/Modules/Notes/Commands/UpdateNote.cs
+++ b/blotztask-api/Modules/Notes/Commands/UpdateNote.cs
@@ -13,7 +13,7 @@ public class UpdateNoteCommand
   [Required] public required Guid NoteId { get; set; }
   [Required] public required string Text { get; set; }
   [Required] public required Guid UserId { get; set; }
-  [Required] public bool IsPersistent { get; set; }
+  [Required] public required bool IsPersistent { get; set; }
 
 }
 public class UpdateNoteCommandHandler(BlotzTaskDbContext db, ILogger<UpdateNoteCommandHandler> logger)

--- a/blotztask-api/Modules/Notes/Controllers/NotesController.cs
+++ b/blotztask-api/Modules/Notes/Controllers/NotesController.cs
@@ -26,7 +26,8 @@ public class NotesController(
         var command = new CreateNoteCommand
         {
             UserId = userId,
-            Text = request.Text
+            Text = request.Text,
+            IsPersistent = request.IsPersistent
         };
         return await createNoteCommandHandler.Handle(command, ct);
     }
@@ -65,7 +66,8 @@ public class NotesController(
         {
             NoteId = id,
             UserId = userId,
-            Text = dto.Text
+            Text = dto.Text,
+            IsPersistent = dto.IsPersistent
         };
         return await updateNoteCommandHandler.Handle(command, ct);
     }

--- a/blotztask-api/Modules/Notes/Controllers/NotesController.cs
+++ b/blotztask-api/Modules/Notes/Controllers/NotesController.cs
@@ -27,7 +27,7 @@ public class NotesController(
         {
             UserId = userId,
             Text = request.Text,
-            IsPersistent = request.IsPersistent ?? false
+            IsPersistent = request.IsPersistent
         };
         return await createNoteCommandHandler.Handle(command, ct);
     }

--- a/blotztask-api/Modules/Notes/Controllers/NotesController.cs
+++ b/blotztask-api/Modules/Notes/Controllers/NotesController.cs
@@ -27,7 +27,7 @@ public class NotesController(
         {
             UserId = userId,
             Text = request.Text,
-            IsPersistent = request.IsPersistent
+            IsPersistent = request.IsPersistent ?? false
         };
         return await createNoteCommandHandler.Handle(command, ct);
     }

--- a/blotztask-api/Modules/Notes/DTOs/NoteDto.cs
+++ b/blotztask-api/Modules/Notes/DTOs/NoteDto.cs
@@ -6,5 +6,6 @@ public class NoteDto
   public string Text { get; set; }
   public DateTime CreatedAt { get; set; }
   public DateTime UpdatedAt { get; set; }
+  public bool IsPersistent { get; set; }
 
 }

--- a/blotztask-api/Modules/Notes/DTOs/NoteRequestDto.cs
+++ b/blotztask-api/Modules/Notes/DTOs/NoteRequestDto.cs
@@ -5,5 +5,5 @@ namespace BlotzTask.Modules.Notes.DTOs;
 public class NoteRequestDto
 {
   [Required] public string Text { get; set; } = string.Empty;
-  [Required] public bool IsPersistent { get; set; }
+  public bool? IsPersistent { get; set; }
 }

--- a/blotztask-api/Modules/Notes/DTOs/NoteRequestDto.cs
+++ b/blotztask-api/Modules/Notes/DTOs/NoteRequestDto.cs
@@ -5,4 +5,5 @@ namespace BlotzTask.Modules.Notes.DTOs;
 public class NoteRequestDto
 {
   [Required] public string Text { get; set; } = string.Empty;
+  public bool IsPersistent { get; set; }
 }

--- a/blotztask-api/Modules/Notes/DTOs/NoteRequestDto.cs
+++ b/blotztask-api/Modules/Notes/DTOs/NoteRequestDto.cs
@@ -5,5 +5,5 @@ namespace BlotzTask.Modules.Notes.DTOs;
 public class NoteRequestDto
 {
   [Required] public string Text { get; set; } = string.Empty;
-  public bool IsPersistent { get; set; }
+  [Required] public bool IsPersistent { get; set; }
 }

--- a/blotztask-api/Modules/Notes/Domain/Note.cs
+++ b/blotztask-api/Modules/Notes/Domain/Note.cs
@@ -11,6 +11,7 @@ public class Note
   public string Text { get; set; } = string.Empty;
   public DateTime CreatedAt { get; set; }
   public DateTime UpdatedAt { get; set; }
+  public bool IsPersistent { get; set; }
   public Guid UserId { get; set; }
   public AppUser? User { get; set; }
 

--- a/blotztask-api/Modules/Notes/Queries/SearchNotes.cs
+++ b/blotztask-api/Modules/Notes/Queries/SearchNotes.cs
@@ -31,7 +31,8 @@ public class SearchNotesQueryHandler(BlotzTaskDbContext db, ILogger<SearchNotesQ
                         Id = n.Id,
                         Text = n.Text,
                         CreatedAt = n.CreatedAt,
-                        UpdatedAt = n.UpdatedAt
+                        UpdatedAt = n.UpdatedAt,
+                        IsPersistent = n.IsPersistent
                       })
                       .ToListAsync(ct);
 

--- a/blotztask-api/Modules/Users/Services/DefaultOnboardingData.cs
+++ b/blotztask-api/Modules/Users/Services/DefaultOnboardingData.cs
@@ -93,6 +93,7 @@ public static class DefaultOnboardingData
                 {
                     Text = "欢迎使用 BlotzTask！这是你的第一条笔记。",
                     UserId = userId,
+                    IsPersistent = true,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 },
@@ -100,6 +101,7 @@ public static class DefaultOnboardingData
                 {
                     Text = "你可以用笔记快速记录想法和灵感。",
                     UserId = userId,
+                    IsPersistent = true,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 },
@@ -107,6 +109,7 @@ public static class DefaultOnboardingData
                 {
                     Text = "笔记适合记录那些暂时不需要截止日期的事情。",
                     UserId = userId,
+                    IsPersistent = true,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 },
@@ -114,6 +117,7 @@ public static class DefaultOnboardingData
                 {
                     Text = "试着创建一条属于你的笔记吧！",
                     UserId = userId,
+                    IsPersistent = true,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 }
@@ -126,6 +130,7 @@ public static class DefaultOnboardingData
             {
                 Text = "Welcome to BlotzTask! This is your first note.",
                 UserId = userId,
+                IsPersistent = true,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             },
@@ -133,6 +138,7 @@ public static class DefaultOnboardingData
             {
                 Text = "You can use notes to capture quick thoughts and ideas.",
                 UserId = userId,
+                IsPersistent = true,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             },
@@ -140,6 +146,7 @@ public static class DefaultOnboardingData
             {
                 Text = "Notes are perfect for things that don't need a due date.",
                 UserId = userId,
+                IsPersistent = true,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             },
@@ -147,6 +154,7 @@ public static class DefaultOnboardingData
             {
                 Text = "Try creating your own note!",
                 UserId = userId,
+                IsPersistent = true,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             }

--- a/blotztask-api/Modules/Users/Services/DefaultOnboardingData.cs
+++ b/blotztask-api/Modules/Users/Services/DefaultOnboardingData.cs
@@ -93,7 +93,6 @@ public static class DefaultOnboardingData
                 {
                     Text = "欢迎使用 BlotzTask！这是你的第一条笔记。",
                     UserId = userId,
-                    IsPersistent = true,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 },
@@ -101,7 +100,6 @@ public static class DefaultOnboardingData
                 {
                     Text = "你可以用笔记快速记录想法和灵感。",
                     UserId = userId,
-                    IsPersistent = true,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 },
@@ -109,7 +107,6 @@ public static class DefaultOnboardingData
                 {
                     Text = "笔记适合记录那些暂时不需要截止日期的事情。",
                     UserId = userId,
-                    IsPersistent = true,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 },
@@ -117,7 +114,6 @@ public static class DefaultOnboardingData
                 {
                     Text = "试着创建一条属于你的笔记吧！",
                     UserId = userId,
-                    IsPersistent = true,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 }
@@ -130,7 +126,6 @@ public static class DefaultOnboardingData
             {
                 Text = "Welcome to BlotzTask! This is your first note.",
                 UserId = userId,
-                IsPersistent = true,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             },
@@ -138,7 +133,6 @@ public static class DefaultOnboardingData
             {
                 Text = "You can use notes to capture quick thoughts and ideas.",
                 UserId = userId,
-                IsPersistent = true,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             },
@@ -146,7 +140,6 @@ public static class DefaultOnboardingData
             {
                 Text = "Notes are perfect for things that don't need a due date.",
                 UserId = userId,
-                IsPersistent = true,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             },
@@ -154,7 +147,6 @@ public static class DefaultOnboardingData
             {
                 Text = "Try creating your own note!",
                 UserId = userId,
-                IsPersistent = true,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             }

--- a/blotztask-api/Modules/Users/Services/DefaultOnboardingData.cs
+++ b/blotztask-api/Modules/Users/Services/DefaultOnboardingData.cs
@@ -93,7 +93,7 @@ public static class DefaultOnboardingData
                 {
                     Text = "欢迎使用 BlotzTask！这是你的第一条笔记。",
                     UserId = userId,
-                    IsPersistent = true,
+                    IsPersistent = false,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 },
@@ -101,7 +101,7 @@ public static class DefaultOnboardingData
                 {
                     Text = "你可以用笔记快速记录想法和灵感。",
                     UserId = userId,
-                    IsPersistent = true,
+                    IsPersistent = false,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 },
@@ -109,7 +109,7 @@ public static class DefaultOnboardingData
                 {
                     Text = "笔记适合记录那些暂时不需要截止日期的事情。",
                     UserId = userId,
-                    IsPersistent = true,
+                    IsPersistent = false,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 },
@@ -117,7 +117,7 @@ public static class DefaultOnboardingData
                 {
                     Text = "试着创建一条属于你的笔记吧！",
                     UserId = userId,
-                    IsPersistent = true,
+                    IsPersistent = false,
                     CreatedAt = utcNow,
                     UpdatedAt = utcNow
                 }
@@ -130,7 +130,7 @@ public static class DefaultOnboardingData
             {
                 Text = "Welcome to BlotzTask! This is your first note.",
                 UserId = userId,
-                IsPersistent = true,
+                IsPersistent = false,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             },
@@ -138,7 +138,7 @@ public static class DefaultOnboardingData
             {
                 Text = "You can use notes to capture quick thoughts and ideas.",
                 UserId = userId,
-                IsPersistent = true,
+                IsPersistent = false,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             },
@@ -146,7 +146,7 @@ public static class DefaultOnboardingData
             {
                 Text = "Notes are perfect for things that don't need a due date.",
                 UserId = userId,
-                IsPersistent = true,
+                IsPersistent = false,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             },
@@ -154,7 +154,7 @@ public static class DefaultOnboardingData
             {
                 Text = "Try creating your own note!",
                 UserId = userId,
-                IsPersistent = true,
+                IsPersistent = false,
                 CreatedAt = utcNow,
                 UpdatedAt = utcNow
             }

--- a/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
@@ -115,7 +115,7 @@ export default function AiTaskSheetScreen() {
 
     const results = await Promise.allSettled([
       ...displayTasks.map((task) => addTaskAsync(convertAiTaskToTaskUpsertDTO(task))),
-      ...displayNotes.map((n) => createNoteAsync(n.text)),
+      ...displayNotes.map((n) => createNoteAsync({ text: n.text, isPersistent: false })),
     ]);
 
     const allSucceeded = results.every((r) => r.status === "fulfilled");

--- a/blotztask-mobile/src/feature/badge/components/badge-share-card.tsx
+++ b/blotztask-mobile/src/feature/badge/components/badge-share-card.tsx
@@ -9,6 +9,53 @@ interface BadgeShareCardProps {
   badge: BadgeNotificationDTO;
 }
 
+function ShareCardTriangle({
+  left,
+  top,
+  size,
+  rotation,
+}: {
+  left: number;
+  top: number;
+  size: number;
+  rotation: number;
+}) {
+  return (
+    <View
+      pointerEvents="none"
+      className="absolute border-x-transparent border-b-[#BCD8FF]"
+      style={{
+        left,
+        top,
+        borderLeftWidth: size / 2,
+        borderRightWidth: size / 2,
+        borderBottomWidth: size,
+        transform: [{ rotate: `${rotation}deg` }],
+      }}
+    />
+  );
+}
+
+// Decorative positions mapped from the Figma share-card background reference
+// (795x1024 source scaled to the 326x412 captured card).
+const BG_TRIANGLES = [
+  { left: 33, top: 33, size: 9, rotation: 72 },
+  { left: 233, top: 36, size: 15, rotation: 88 },
+  { left: 138, top: 49, size: 9, rotation: 49 },
+  { left: 279, top: 73, size: 5, rotation: -112 },
+  { left: 201, top: 69, size: 13, rotation: -99 },
+  { left: 26, top: 82, size: 11, rotation: -84 },
+  { left: 97, top: 94, size: 8, rotation: 42 },
+  { left: 235, top: 138, size: 8, rotation: 53 },
+  { left: 238, top: 229, size: 10, rotation: 154 },
+  { left: 56, top: 229, size: 11, rotation: 154 },
+  { left: 177, top: 243, size: 11, rotation: 142 },
+  { left: 278, top: 251, size: 8, rotation: 118 },
+  { left: 122, top: 288, size: 9, rotation: -172 },
+  { left: 25, top: 315, size: 12, rotation: -110 },
+  { left: 248, top: 338, size: 8, rotation: 65 },
+];
+
 function ShareCardBackground() {
   return (
     <View pointerEvents="none" className="absolute inset-0 z-0">
@@ -18,6 +65,10 @@ function ShareCardBackground() {
       <View className="absolute left-[234px] top-[136px]">
         <ASSETS.whiteBun width={143} height={124} />
       </View>
+
+      {BG_TRIANGLES.map((tri, i) => (
+        <ShareCardTriangle key={`tri-${i}`} {...tri} />
+      ))}
     </View>
   );
 }
@@ -51,6 +102,7 @@ export const BadgeShareCard = forwardRef<View, BadgeShareCardProps>(function Bad
 
           <Text
             className="mt-4 w-full text-secondary text-[25px] font-balooBold text-center leading-9"
+            numberOfLines={2}
           >
             {badge.name}
           </Text>

--- a/blotztask-mobile/src/feature/notes/hooks/useNotesMutation.ts
+++ b/blotztask-mobile/src/feature/notes/hooks/useNotesMutation.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createNote, deleteNote, updateNote } from "../services/notes-service";
 import { EditNoteDTO } from "../models/edit-note-dto";
 import { noteKeys } from "@/shared/constants/query-key-factory";
+import { CreateNoteDTO } from "../models/create-note-dto";
 
 export const useNotesMutation = () => {
   const queryClient = useQueryClient();
@@ -14,7 +15,7 @@ export const useNotesMutation = () => {
   });
 
   const createNoteMutation = useMutation({
-    mutationFn: (text: string) => createNote(text),
+    mutationFn: (createNoteDto: CreateNoteDTO) => createNote(createNoteDto),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: noteKeys.all });
     },

--- a/blotztask-mobile/src/feature/notes/models/create-note-dto.ts
+++ b/blotztask-mobile/src/feature/notes/models/create-note-dto.ts
@@ -1,0 +1,4 @@
+export interface CreateNoteDTO {
+  text: string;
+  isPersistent: boolean;
+}

--- a/blotztask-mobile/src/feature/notes/models/edit-note-dto.ts
+++ b/blotztask-mobile/src/feature/notes/models/edit-note-dto.ts
@@ -1,4 +1,5 @@
 export interface EditNoteDTO {
   id: string;
   text: string;
+  isPersistent: boolean;
 }

--- a/blotztask-mobile/src/feature/notes/models/note-dto.ts
+++ b/blotztask-mobile/src/feature/notes/models/note-dto.ts
@@ -2,4 +2,5 @@ export interface NoteDTO {
   id: string;
   text: string;
   createdAt: string;
+  isPersistent: boolean;
 }

--- a/blotztask-mobile/src/feature/notes/screens/note-editor-screen.tsx
+++ b/blotztask-mobile/src/feature/notes/screens/note-editor-screen.tsx
@@ -6,22 +6,26 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 import { useTranslation } from "react-i18next";
 
 import { useNotesMutation } from "@/feature/notes/hooks/useNotesMutation";
+import { ToggleSwitch } from "@/feature/settings/components/toggle-switch";
 import { ReturnButton } from "@/shared/components/return-button";
 import { theme } from "@/shared/constants/theme";
 
 type NoteEditorParams = {
   noteId?: string;
   noteText?: string;
+  isPersistent?: string;
 };
 
 export default function NoteEditorScreen() {
   const router = useRouter();
   const { t } = useTranslation("notes");
 
-  const { noteId, noteText: initialTextParam } = useLocalSearchParams<NoteEditorParams>();
+  const { noteId, noteText: initialTextParam, isPersistent: initialIsPersistentParam } =
+    useLocalSearchParams<NoteEditorParams>();
   const initialText = initialTextParam ?? "";
 
   const [noteText, setNoteText] = useState(initialText);
+  const [isPersistent, setIsPersistent] = useState(initialIsPersistentParam === "true");
   const { createNote, isNoteCreating, updateNote, isNoteUpdating } = useNotesMutation();
 
   const isSaving = noteId ? isNoteUpdating : isNoteCreating;
@@ -33,7 +37,7 @@ export default function NoteEditorScreen() {
 
     if (noteId) {
       updateNote(
-        { id: noteId, text: trimmedText },
+        { id: noteId, text: trimmedText, isPersistent },
         {
           onSuccess: () => {
             router.back();
@@ -43,7 +47,7 @@ export default function NoteEditorScreen() {
       return;
     }
 
-    createNote(trimmedText, {
+    createNote({ text: trimmedText, isPersistent }, {
       onSuccess: () => {
         router.back();
       },
@@ -87,6 +91,11 @@ export default function NoteEditorScreen() {
             textAlignVertical="top"
             className="mt-4 flex-1 rounded-3xl bg-white px-5 py-5 font-baloo text-lg text-black"
           />
+
+          <View className="mt-4 flex-row items-center justify-between rounded-2xl bg-white px-5 py-4">
+            <Text className="font-baloo text-lg text-black">{t("persistentNote")}</Text>
+            <ToggleSwitch value={isPersistent} onChange={() => setIsPersistent(!isPersistent)} />
+          </View>
         </View>
       </KeyboardAvoidingView>
     </SafeAreaView>

--- a/blotztask-mobile/src/feature/notes/screens/notes-screen.tsx
+++ b/blotztask-mobile/src/feature/notes/screens/notes-screen.tsx
@@ -53,6 +53,7 @@ export default function NotesScreen() {
       params: {
         noteId: note.id,
         noteText: note.text,
+        isPersistent: String(note.isPersistent),
       },
     });
   };

--- a/blotztask-mobile/src/feature/notes/services/notes-service.ts
+++ b/blotztask-mobile/src/feature/notes/services/notes-service.ts
@@ -1,6 +1,7 @@
 import { apiClient } from "@/shared/services/api/client";
 import { NoteDTO } from "../models/note-dto";
 import { EditNoteDTO } from "../models/edit-note-dto";
+import { CreateNoteDTO } from "../models/create-note-dto";
 
 export const searchNotes = async (keyword: string): Promise<NoteDTO[]> => {
   const url = `/notes`;
@@ -15,16 +16,22 @@ export const deleteNote = async (noteId: string): Promise<void> => {
   return await apiClient.delete(url);
 };
 
-export const createNote = async (text: string): Promise<NoteDTO> => {
+export const createNote = async (createNoteDto: CreateNoteDTO): Promise<NoteDTO> => {
   const url = `/notes`;
 
-  return await apiClient.post(url, { text });
+  return await apiClient.post(url, {
+    text: createNoteDto.text,
+    isPersistent: createNoteDto.isPersistent,
+  });
 };
 
 export const updateNote = async (editNoteDto: EditNoteDTO): Promise<NoteDTO> => {
   const url = `/notes/${editNoteDto.id}`;
 
-  return await apiClient.put(url, { text: editNoteDto.text });
+  return await apiClient.put(url, {
+    text: editNoteDto.text,
+    isPersistent: editNoteDto.isPersistent,
+  });
 };
 
 export const convertNoteToTask = async (

--- a/blotztask-mobile/src/i18n/locales/en/notes.json
+++ b/blotztask-mobile/src/i18n/locales/en/notes.json
@@ -23,6 +23,7 @@
   },
 
   "notePlaceholder": "Add a Quick Note",
+  "persistentNote": "Persistent Note",
   "save": "Save",
   "close": "Close",
 

--- a/blotztask-mobile/src/i18n/locales/zh/notes.json
+++ b/blotztask-mobile/src/i18n/locales/zh/notes.json
@@ -23,6 +23,7 @@
   },
 
   "notePlaceholder": "加一个笔记",
+  "persistentNote": "持久随手记",
   "save": "保存",
   "close": "关闭",
 


### PR DESCRIPTION
## Summary

- Expose persistent Notes in the mobile Notes editor.
- Send `isPersistent` through mobile Notes create/update calls.
- Keep AI-generated notes non-persistent by default.

## Release note

> Add a Persistent Note option so notes can remain available after being turned into tasks.

**Status:**

- [x] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce

## Validation

- `npm run lint` in `blotztask-mobile/` passed with existing warnings.
- `npx tsc --noEmit` is blocked by pre-existing dependency/source errors outside the touched files.
