### PR TITLE
[codex] Add frontend control for persistent notes

### DIFF
--- a/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
@@ -115,7 +115,7 @@ export default function AiTaskSheetScreen() {
 
     const results = await Promise.allSettled([
       ...displayTasks.map((task) => addTaskAsync(convertAiTaskToTaskUpsertDTO(task))),
-      ...displayNotes.map((n) => createNoteAsync(n.text)),
+      ...displayNotes.map((n) => createNoteAsync({ text: n.text, isPersistent: false })),
     ]);
 
     const allSucceeded = results.every((r) => r.status === "fulfilled");

--- a/blotztask-mobile/src/feature/notes/hooks/useNotesMutation.ts
+++ b/blotztask-mobile/src/feature/notes/hooks/useNotesMutation.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createNote, deleteNote, updateNote } from "../services/notes-service";
 import { EditNoteDTO } from "../models/edit-note-dto";
 import { noteKeys } from "@/shared/constants/query-key-factory";
+import { CreateNoteDTO } from "../models/create-note-dto";
 
 export const useNotesMutation = () => {
   const queryClient = useQueryClient();
@@ -14,7 +15,7 @@ export const useNotesMutation = () => {
   });
 
   const createNoteMutation = useMutation({
-    mutationFn: (text: string) => createNote(text),
+    mutationFn: (createNoteDto: CreateNoteDTO) => createNote(createNoteDto),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: noteKeys.all });
     },

--- a/blotztask-mobile/src/feature/notes/models/create-note-dto.ts
+++ b/blotztask-mobile/src/feature/notes/models/create-note-dto.ts
@@ -1,0 +1,4 @@
+export interface CreateNoteDTO {
+  text: string;
+  isPersistent: boolean;
+}

--- a/blotztask-mobile/src/feature/notes/models/edit-note-dto.ts
+++ b/blotztask-mobile/src/feature/notes/models/edit-note-dto.ts
@@ -1,4 +1,5 @@
 export interface EditNoteDTO {
   id: string;
   text: string;
+  isPersistent: boolean;
 }

--- a/blotztask-mobile/src/feature/notes/models/note-dto.ts
+++ b/blotztask-mobile/src/feature/notes/models/note-dto.ts
@@ -2,4 +2,5 @@ export interface NoteDTO {
   id: string;
   text: string;
   createdAt: string;
+  isPersistent: boolean;
 }

--- a/blotztask-mobile/src/feature/notes/screens/note-editor-screen.tsx
+++ b/blotztask-mobile/src/feature/notes/screens/note-editor-screen.tsx
@@ -6,22 +6,26 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 import { useTranslation } from "react-i18next";
 
 import { useNotesMutation } from "@/feature/notes/hooks/useNotesMutation";
+import { ToggleSwitch } from "@/feature/settings/components/toggle-switch";
 import { ReturnButton } from "@/shared/components/return-button";
 import { theme } from "@/shared/constants/theme";
 
 type NoteEditorParams = {
   noteId?: string;
   noteText?: string;
+  isPersistent?: string;
 };
 
 export default function NoteEditorScreen() {
   const router = useRouter();
   const { t } = useTranslation("notes");
 
-  const { noteId, noteText: initialTextParam } = useLocalSearchParams<NoteEditorParams>();
+  const { noteId, noteText: initialTextParam, isPersistent: initialIsPersistentParam } =
+    useLocalSearchParams<NoteEditorParams>();
   const initialText = initialTextParam ?? "";
 
   const [noteText, setNoteText] = useState(initialText);
+  const [isPersistent, setIsPersistent] = useState(initialIsPersistentParam === "true");
   const { createNote, isNoteCreating, updateNote, isNoteUpdating } = useNotesMutation();
 
   const isSaving = noteId ? isNoteUpdating : isNoteCreating;
@@ -33,7 +37,7 @@ export default function NoteEditorScreen() {
 
     if (noteId) {
       updateNote(
-        { id: noteId, text: trimmedText },
+        { id: noteId, text: trimmedText, isPersistent },
         {
           onSuccess: () => {
             router.back();
@@ -43,7 +47,7 @@ export default function NoteEditorScreen() {
       return;
     }
 
-    createNote(trimmedText, {
+    createNote({ text: trimmedText, isPersistent }, {
       onSuccess: () => {
         router.back();
       },
@@ -87,6 +91,11 @@ export default function NoteEditorScreen() {
             textAlignVertical="top"
             className="mt-4 flex-1 rounded-3xl bg-white px-5 py-5 font-baloo text-lg text-black"
           />
+
+          <View className="mt-4 flex-row items-center justify-between rounded-2xl bg-white px-5 py-4">
+            <Text className="font-baloo text-lg text-black">{t("persistentNote")}</Text>
+            <ToggleSwitch value={isPersistent} onChange={() => setIsPersistent(!isPersistent)} />
+          </View>
         </View>
       </KeyboardAvoidingView>
     </SafeAreaView>

--- a/blotztask-mobile/src/feature/notes/screens/notes-screen.tsx
+++ b/blotztask-mobile/src/feature/notes/screens/notes-screen.tsx
@@ -53,6 +53,7 @@ export default function NotesScreen() {
       params: {
         noteId: note.id,
         noteText: note.text,
+        isPersistent: String(note.isPersistent),
       },
     });
   };

--- a/blotztask-mobile/src/feature/notes/services/notes-service.ts
+++ b/blotztask-mobile/src/feature/notes/services/notes-service.ts
@@ -1,6 +1,7 @@
 import { apiClient } from "@/shared/services/api/client";
 import { NoteDTO } from "../models/note-dto";
 import { EditNoteDTO } from "../models/edit-note-dto";
+import { CreateNoteDTO } from "../models/create-note-dto";
 
 export const searchNotes = async (keyword: string): Promise<NoteDTO[]> => {
   const url = `/notes`;
@@ -15,16 +16,22 @@ export const deleteNote = async (noteId: string): Promise<void> => {
   return await apiClient.delete(url);
 };
 
-export const createNote = async (text: string): Promise<NoteDTO> => {
+export const createNote = async (createNoteDto: CreateNoteDTO): Promise<NoteDTO> => {
   const url = `/notes`;
 
-  return await apiClient.post(url, { text });
+  return await apiClient.post(url, {
+    text: createNoteDto.text,
+    isPersistent: createNoteDto.isPersistent,
+  });
 };
 
 export const updateNote = async (editNoteDto: EditNoteDTO): Promise<NoteDTO> => {
   const url = `/notes/${editNoteDto.id}`;
 
-  return await apiClient.put(url, { text: editNoteDto.text });
+  return await apiClient.put(url, {
+    text: editNoteDto.text,
+    isPersistent: editNoteDto.isPersistent,
+  });
 };
 
 export const convertNoteToTask = async (

--- a/blotztask-mobile/src/i18n/locales/en/notes.json
+++ b/blotztask-mobile/src/i18n/locales/en/notes.json
@@ -23,6 +23,7 @@
   },
 
   "notePlaceholder": "Add a Quick Note",
+  "persistentNote": "Persistent Note",
   "save": "Save",
   "close": "Close",
 

--- a/blotztask-mobile/src/i18n/locales/zh/notes.json
+++ b/blotztask-mobile/src/i18n/locales/zh/notes.json
@@ -23,7 +23,7 @@
   },
 
   "notePlaceholder": "加一个笔记",
-  "persistentNote": "持久随手记",
+  "persistentNote": "永久笔记",
   "save": "保存",
   "close": "关闭",
 

--- a/blotztask-mobile/src/i18n/locales/zh/notes.json
+++ b/blotztask-mobile/src/i18n/locales/zh/notes.json
@@ -23,6 +23,7 @@
   },
 
   "notePlaceholder": "加一个笔记",
+  "persistentNote": "持久随手记",
   "save": "保存",
   "close": "关闭",
 


### PR DESCRIPTION
## Summary

- Expose a minimal Persistent Note toggle in the mobile Note editor.
- Send `isPersistent` through mobile Note create/update requests.
- Keep AI-generated notes non-persistent by default.

Refs Blotz-Org/Blotz-Task-App-Private#1468

## Release note

> Add a Persistent Note option so notes can remain available after being turned into tasks.

**Status:**

- [x] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce

## Validation

- `npm run lint` in `blotztask-mobile/` passed with existing warnings.
