### PR TITLE
[codex] Sync rejected AI draft tasks

### DIFF
--- a/blotztask-api/Modules/ChatTaskGenerator/AiTaskGenerateChatHub.cs
+++ b/blotztask-api/Modules/ChatTaskGenerator/AiTaskGenerateChatHub.cs
@@ -1,4 +1,5 @@
 using BlotzTask.Modules.ChatTaskGenerator.Services;
+using BlotzTask.Modules.ChatTaskGenerator.Dtos;
 using BlotzTask.Modules.Users.Enums;
 using BlotzTask.Modules.Users.Queries;
 using BlotzTask.Shared.Exceptions;
@@ -79,6 +80,12 @@ public class AiTaskGenerateChatHub(
         // 5. Stamp the original user message and send the authoritative final result for reconciliation
         resultMessage.UserInput = message;
         await Clients.Caller.SendAsync("ReceiveGenerationResult", resultMessage, ct);
+    }
+
+    public Task<AiGenerateMessage> RejectDraftTask(Guid taskId)
+    {
+        var chatContext = (AiChatContext)Context.Items["ChatContext"]!;
+        return Task.FromResult(chatContext.RejectDraftTask(taskId));
     }
 
     public async Task TranscribeAudio(byte[] audioData)

--- a/blotztask-api/Modules/ChatTaskGenerator/Dtos/AiChatContext.cs
+++ b/blotztask-api/Modules/ChatTaskGenerator/Dtos/AiChatContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.Agents.AI;
+using BlotzTask.Modules.ChatTaskGenerator.Dtos;
 using BlotzTask.Modules.ChatTaskGenerator.Functions;
 
 namespace BlotzTask.Modules.ChatTaskGenerator;
@@ -22,4 +23,46 @@ public class AiChatContext
 
     /// <summary>The user's local time zone, used to resolve relative date/time references in their input.</summary>
     public required TimeZoneInfo TimeZone { get; init; }
+
+    public List<RejectedDraftTask> RejectedDraftTasks { get; } = [];
+
+    public AiGenerateMessage RejectDraftTask(Guid taskId)
+    {
+        var rejectedTask = Tools.RemoveTaskById(taskId);
+        if (rejectedTask != null)
+            RejectedDraftTasks.Add(RejectedDraftTask.From(rejectedTask));
+
+        return ToGenerateMessage();
+    }
+
+    public AiGenerateMessage ToGenerateMessage(int inputTokens = 0, int outputTokens = 0, int totalTokens = 0)
+    {
+        return new AiGenerateMessage
+        {
+            ExtractedTasks = Tools.Tasks,
+            ExtractedNotes = Tools.Notes,
+            InputTokens = inputTokens,
+            OutputTokens = outputTokens,
+            TotalTokens = totalTokens
+        };
+    }
+}
+
+public class RejectedDraftTask
+{
+    public required Guid Id { get; init; }
+    public required string Title { get; init; }
+    public required DateTime StartTime { get; init; }
+    public required DateTime EndTime { get; init; }
+
+    public static RejectedDraftTask From(ExtractedTask task)
+    {
+        return new RejectedDraftTask
+        {
+            Id = task.Id,
+            Title = task.Title,
+            StartTime = task.StartTime,
+            EndTime = task.EndTime
+        };
+    }
 }

--- a/blotztask-api/Modules/ChatTaskGenerator/Functions/TaskGenerationTools.cs
+++ b/blotztask-api/Modules/ChatTaskGenerator/Functions/TaskGenerationTools.cs
@@ -15,6 +15,14 @@ public class TaskGenerationTools()
 
     public void ResetCallCount() => ToolCallCount = 0;
 
+    public ExtractedTask? RemoveTaskById(Guid id)
+    {
+        var task = Tasks.FirstOrDefault(t => t.Id == id);
+        if (task == null) return null;
+        Tasks.Remove(task);
+        return task;
+    }
+
     [Description("Add multiple tasks at once. Prefer this over CreateTask when the user mentions more than one task. Assign sequential, non-overlapping times — estimate a realistic duration for each task and start the next where the previous ends.")]
     public async Task<string> CreateTasks(
         [Description("Array of task titles")] string[] titles,

--- a/blotztask-api/Modules/ChatTaskGenerator/Services/AiChatService.cs
+++ b/blotztask-api/Modules/ChatTaskGenerator/Services/AiChatService.cs
@@ -82,7 +82,10 @@ public class AiChatService(
             logger.LogInformation("TaskGeneration: Invoking AI with deployment={DeploymentId}", _deploymentId);
 
             var runSw = Stopwatch.StartNew();
-            var response = await context.Agent.RunAsync(userMessage, context.Session, cancellationToken: ct);
+            var response = await context.Agent.RunAsync(
+                BuildRunMessages(userMessage, context),
+                context.Session,
+                cancellationToken: ct);
             runSw.Stop();
 
             inputTokens = (int)(response.Usage?.InputTokenCount ?? 0);
@@ -128,13 +131,36 @@ public class AiChatService(
         if (context.Tools.ToolCallCount <= 0)
             throw new AiTaskGenerationException(AiErrorCode.NoTasksExtracted, "No tasks or notes were extracted.");
 
-        return new AiGenerateMessage
-        {
-            ExtractedTasks = context.Tools.Tasks,
-            ExtractedNotes = context.Tools.Notes,
-            InputTokens = inputTokens,
-            OutputTokens = outputTokens,
-            TotalTokens = totalTokens
-        };
+        return context.ToGenerateMessage(inputTokens, outputTokens, totalTokens);
+    }
+
+    private static ChatMessage[] BuildRunMessages(string userMessage, AiChatContext context)
+    {
+        var userMessageChat = new ChatMessage(ChatRole.User, userMessage);
+        if (context.RejectedDraftTasks.Count == 0)
+            return [userMessageChat];
+
+        return
+        [
+            new ChatMessage(ChatRole.User, BuildRejectedDraftContextMessage(context.RejectedDraftTasks)),
+            userMessageChat
+        ];
+    }
+
+    private static string BuildRejectedDraftContextMessage(IReadOnlyCollection<RejectedDraftTask> rejectedDraftTasks)
+    {
+        var rejectedTaskLines = rejectedDraftTasks
+            .Select(task =>
+            {
+                var title = task.Title.ReplaceLineEndings(" ").Trim();
+                return $"- Id: {task.Id}; Title: {title}; Start: {task.StartTime:yyyy-MM-ddTHH:mm:ss}; End: {task.EndTime:yyyy-MM-ddTHH:mm:ss}";
+            });
+
+        return $"""
+                Context from the app UI:
+                The user has rejected these unsaved draft tasks in this AI sheet session. Do not update or recreate them unless the user explicitly asks to add them again.
+                Rejected draft tasks:
+                {string.Join(Environment.NewLine, rejectedTaskLines)}
+                """;
     }
 }

--- a/blotztask-mobile/src/feature/ai-task-generate/component/ai-result-card.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/component/ai-result-card.tsx
@@ -11,9 +11,16 @@ type Props = {
   label?: LabelDTO;
   startTime?: string;
   endTime?: string;
+  containerClassName?: string;
 };
 
-export function AiResultCard({ text, label, startTime, endTime }: Props) {
+export function AiResultCard({
+  text,
+  label,
+  startTime,
+  endTime,
+  containerClassName = "w-[88%]",
+}: Props) {
   const isTask = startTime !== undefined;
   const formatTime = isTask
     ? formatAiTaskCardTime({ startTime: startTime!, endTime: endTime! })
@@ -27,7 +34,7 @@ export function AiResultCard({ text, label, startTime, endTime }: Props) {
       entering={MotionAnimations.upEntering}
       exiting={MotionAnimations.outExiting}
       layout={MotionAnimations.layout}
-      className="bg-white rounded-2xl flex-row items-center shadow-md w-[88%] justify-between pl-6 pr-4 pt-4 pb-3 my-4"
+      className={`bg-white rounded-2xl flex-row items-center shadow-md justify-between pl-6 pr-4 pt-4 pb-3 my-4 ${containerClassName}`}
     >
       {isTask && (
         <View
@@ -55,7 +62,6 @@ export function AiResultCard({ text, label, startTime, endTime }: Props) {
           </View>
         )}
       </View>
-
     </Animated.View>
   );
 }

--- a/blotztask-mobile/src/feature/ai-task-generate/component/ai-result-list.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/component/ai-result-list.tsx
@@ -1,28 +1,37 @@
-import { View, Text } from "react-native";
-import Animated from "react-native-reanimated";
+import { type RefObject, useRef } from "react";
+import { Pressable, View, Text } from "react-native";
+import Animated, { SharedValue, useAnimatedStyle } from "react-native-reanimated";
+import ReanimatedSwipeable, {
+  SwipeableMethods,
+} from "react-native-gesture-handler/ReanimatedSwipeable";
 import { useTranslation } from "react-i18next";
+import MaterialCommunityIcons from "@react-native-vector-icons/material-design-icons/static";
 import { AiResultCard } from "./ai-result-card";
 import { AiTaskDTO } from "../models/ai-task-dto";
 import { AiNoteDTO } from "../models/ai-result-message-dto";
+import { useSwipeableManager } from "@/feature/notes/hooks/useSwipeableManager";
 
 type Props = {
   aiTasks: AiTaskDTO[];
   aiNotes: AiNoteDTO[];
+  canRejectTasks: boolean;
+  onRejectTask: (taskId: string) => void | Promise<void>;
 };
 
-export function AiResultList({ aiTasks, aiNotes }: Props) {
+export function AiResultList({ aiTasks, aiNotes, canRejectTasks, onRejectTask }: Props) {
   const { t } = useTranslation("aiTaskGenerate");
+  const { onRowOpen } = useSwipeableManager();
 
   return (
     <Animated.ScrollView className="w-full flex-1" showsVerticalScrollIndicator={false}>
       <View className="items-center">
         {aiTasks.map((task) => (
-          <AiResultCard
+          <AiTaskSwipeRow
             key={task.id}
-            text={task.title}
-            label={task.label}
-            startTime={task.startTime}
-            endTime={task.endTime}
+            task={task}
+            disabled={!canRejectTasks}
+            onRejectTask={onRejectTask}
+            onRowOpen={onRowOpen}
           />
         ))}
         {aiNotes.length > 0 && (
@@ -31,14 +40,80 @@ export function AiResultList({ aiTasks, aiNotes }: Props) {
               {t("labels.notesSection")}
             </Text>
             {aiNotes.map((note) => (
-              <AiResultCard
-                key={note.id}
-                text={note.text}
-              />
+              <AiResultCard key={note.id} text={note.text} />
             ))}
           </>
         )}
       </View>
     </Animated.ScrollView>
+  );
+}
+
+type AiTaskSwipeRowProps = {
+  task: AiTaskDTO;
+  disabled: boolean;
+  onRejectTask: (taskId: string) => void | Promise<void>;
+  onRowOpen: (ref: RefObject<SwipeableMethods | null>) => void;
+};
+
+function AiTaskSwipeRow({ task, disabled, onRejectTask, onRowOpen }: AiTaskSwipeRowProps) {
+  const swipeRef = useRef<SwipeableMethods | null>(null);
+
+  const handleReject = () => {
+    if (disabled) return;
+    swipeRef.current?.close();
+    void onRejectTask(task.id);
+  };
+
+  return (
+    <View className="w-[88%]">
+      <ReanimatedSwipeable
+        ref={swipeRef}
+        enabled={!disabled}
+        renderRightActions={(progress: SharedValue<number>) => (
+          <AiTaskRejectAction progress={progress} disabled={disabled} onReject={handleReject} />
+        )}
+        rightThreshold={32}
+        overshootRight={false}
+        friction={2}
+        onSwipeableWillOpen={() => {
+          onRowOpen(swipeRef);
+        }}
+      >
+        <AiResultCard
+          text={task.title}
+          label={task.label}
+          startTime={task.startTime}
+          endTime={task.endTime}
+          containerClassName="w-full"
+        />
+      </ReanimatedSwipeable>
+    </View>
+  );
+}
+
+type AiTaskRejectActionProps = {
+  progress: SharedValue<number>;
+  disabled: boolean;
+  onReject: () => void;
+};
+
+function AiTaskRejectAction({ progress, disabled, onReject }: AiTaskRejectActionProps) {
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: 80 * (1 - progress.value) }],
+  }));
+
+  return (
+    <Animated.View className="h-full items-center justify-center pl-3" style={animatedStyle}>
+      <Pressable
+        onPress={onReject}
+        disabled={disabled}
+        className={`h-20 w-20 rounded-3xl bg-red-500/10 items-center justify-center ${
+          disabled ? "opacity-50" : ""
+        }`}
+      >
+        <MaterialCommunityIcons name="trash-can-outline" size={24} color="#F56767" />
+      </Pressable>
+    </Animated.View>
   );
 }

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
@@ -36,6 +36,18 @@ export function useAiTaskGenerator({
   const [turns, setTurns] = useState<AiTaskGenerationTurn[]>([]);
   const requestStartedAtRef = useRef<number | null>(null);
   const pendingInputModeRef = useRef<AiTaskInputMode | null>(null);
+  const streamedTasksRef = useRef<ExtractedTaskDTO[]>([]);
+  const isAiGeneratingRef = useRef(false);
+
+  const updateStreamedTasks = (
+    next: ExtractedTaskDTO[] | ((prev: ExtractedTaskDTO[]) => ExtractedTaskDTO[]),
+  ) => {
+    setStreamedTasks((prev) => {
+      const value = typeof next === "function" ? next(prev) : next;
+      streamedTasksRef.current = value;
+      return value;
+    });
+  };
 
   const submitAudioForTranscription = async (uri: string): Promise<void> => {
     if (!connection || connection.state !== signalR.HubConnectionState.Connected) {
@@ -47,6 +59,7 @@ export function useAiTaskGenerator({
 
     setTranscript(undefined);
     setIsAiGenerating(true);
+    isAiGeneratingRef.current = true;
     requestStartedAtRef.current = Date.now();
     pendingInputModeRef.current = "voice";
 
@@ -55,6 +68,7 @@ export function useAiTaskGenerator({
     } catch (error) {
       console.error("TranscribeAudio invocation failed:", error);
       setIsAiGenerating(false);
+      isAiGeneratingRef.current = false;
       const startedAt = requestStartedAtRef.current;
       requestStartedAtRef.current = null;
       pendingInputModeRef.current = null;
@@ -75,6 +89,7 @@ export function useAiTaskGenerator({
 
     setTranscript(undefined);
     setIsAiGenerating(true);
+    isAiGeneratingRef.current = true;
     requestStartedAtRef.current = Date.now();
     pendingInputModeRef.current = "text";
 
@@ -83,6 +98,7 @@ export function useAiTaskGenerator({
     } catch (error) {
       console.error("SendMessage invocation failed:", error);
       setIsAiGenerating(false);
+      isAiGeneratingRef.current = false;
       const startedAt = requestStartedAtRef.current;
       requestStartedAtRef.current = null;
       pendingInputModeRef.current = null;
@@ -99,6 +115,7 @@ export function useAiTaskGenerator({
   const generationCompleteHandler = (result: AiResultMessageDTO) => {
     setTranscript(undefined);
     setIsAiGenerating(false);
+    isAiGeneratingRef.current = false;
     requestStartedAtRef.current = null;
     const inputMode = pendingInputModeRef.current;
     pendingInputModeRef.current = null;
@@ -109,18 +126,19 @@ export function useAiTaskGenerator({
     }
 
     // Sync to authoritative final list — streaming only covers CreateTask, not RemoveTask/UpdateTask
-    setStreamedTasks(result.extractedTasks ?? []);
+    updateStreamedTasks(result.extractedTasks ?? []);
     setStreamedNotes(result.extractedNotes ?? []);
   };
 
   const generationErrorHandler = (error: AiGenerationErrorDTO) => {
     setTranscript(undefined);
     setIsAiGenerating(false);
+    isAiGeneratingRef.current = false;
     const startedAt = requestStartedAtRef.current;
     requestStartedAtRef.current = null;
     const inputMode = pendingInputModeRef.current;
     pendingInputModeRef.current = null;
-    setStreamedTasks([]);
+    updateStreamedTasks([]);
     setStreamedNotes([]);
 
     analytics.trackAiTaskGenerationFailed({
@@ -137,6 +155,33 @@ export function useAiTaskGenerator({
     Toast.show({ type: "error", text1: t(i18nKey) });
   };
 
+  const rejectDraftTask = async (taskId: string): Promise<void> => {
+    if (
+      isAiGeneratingRef.current ||
+      !connection ||
+      connection.state !== signalR.HubConnectionState.Connected
+    ) {
+      return;
+    }
+
+    const previousTasks = streamedTasksRef.current;
+    updateStreamedTasks((prev) => prev.filter((task) => task.id !== taskId));
+
+    try {
+      const result = await signalRService.invoke<AiResultMessageDTO>(
+        connection,
+        "RejectDraftTask",
+        taskId,
+      );
+      updateStreamedTasks(result.extractedTasks ?? []);
+      setStreamedNotes(result.extractedNotes ?? []);
+    } catch (error) {
+      console.error("RejectDraftTask invocation failed:", error);
+      updateStreamedTasks(previousTasks);
+      Toast.show({ type: "error", text1: t("errors.default") });
+    }
+  };
+
   useEffect(() => {
     let conn: signalR.HubConnection | null = null;
 
@@ -151,7 +196,7 @@ export function useAiTaskGenerator({
         });
         conn.on("ReceiveTaskExtracted", (task: ExtractedTaskDTO) => {
           if (requestStartedAtRef.current == null) return;
-          setStreamedTasks((prev) => [...prev, task]);
+          updateStreamedTasks((prev) => [...prev, task]);
         });
         conn.on("ReceiveNoteExtracted", (note: AiNoteDTO) => {
           if (requestStartedAtRef.current == null) return;
@@ -182,6 +227,7 @@ export function useAiTaskGenerator({
     turns,
     submitAudioForTranscription,
     sendTextMessage,
+    rejectDraftTask,
   };
 }
 

--- a/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
@@ -54,6 +54,7 @@ export default function AiTaskSheetScreen() {
     streamedNotes,
     submitAudioForTranscription,
     sendTextMessage,
+    rejectDraftTask,
   } = useAiTaskGenerator({
     setIsAiGenerating,
   });
@@ -180,7 +181,14 @@ export default function AiTaskSheetScreen() {
               )}
 
               {/* Task / note cards (streamed or final) */}
-              {hasContent && <AiResultList aiTasks={displayTasks} aiNotes={displayNotes} />}
+              {hasContent && (
+                <AiResultList
+                  aiTasks={displayTasks}
+                  aiNotes={displayNotes}
+                  canRejectTasks={!isAiGenerating}
+                  onRejectTask={rejectDraftTask}
+                />
+              )}
 
               {isAiGenerating && !!transcript && (
                 <Text className="mx-6 mb-2 text-center italic text-white/70" numberOfLines={3}>


### PR DESCRIPTION
## Summary

- Add a SignalR `RejectDraftTask` path that removes an AI-generated draft task from the current chat context snapshot.
- Remember rejected draft task summaries for the current AI sheet session and pass that context into later AI responses.
- Add swipe-to-reject UI for generated task draft cards with optimistic removal and rollback on hub failure.

## Release note

> Users can swipe away unwanted AI-generated task draft cards before saving them.

**Status:**

- [x] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce\n- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce