### PR TITLE
Rename Badge API field Title to Name

### DIFF
--- a/blotztask-api/Modules/Badges/Queries/GetBadgeById.cs
+++ b/blotztask-api/Modules/Badges/Queries/GetBadgeById.cs
@@ -28,7 +28,7 @@ public class GetBadgeByIdQueryHandler(BlotzTaskDbContext db, ILogger<GetBadgeByI
         return new BadgeByIdItemDto
         {
             Id = badge.Id,
-            Title = language == Language.Zh ? badge.NameZh : badge.NameEn,
+            Name = language == Language.Zh ? badge.NameZh : badge.NameEn,
             Description = language == Language.Zh ? badge.DescriptionZh : badge.DescriptionEn,
             IconUrl = badge.IconUrl,
             Category = badge.Category.ToString(),
@@ -39,7 +39,7 @@ public class GetBadgeByIdQueryHandler(BlotzTaskDbContext db, ILogger<GetBadgeByI
 public class BadgeByIdItemDto
 {
     public int Id { get; set; }
-    public required string Title { get; set; }      
+    public required string Name { get; set; }
     public required string Description { get; set; }
     public required string IconUrl { get; set; }
     public required string Category { get; set; }

--- a/blotztask-api/Modules/Badges/Queries/GetUserBadges.cs
+++ b/blotztask-api/Modules/Badges/Queries/GetUserBadges.cs
@@ -38,7 +38,7 @@ public class GetUserBadgesQueryHandler(BlotzTaskDbContext db, ILogger<GetUserBad
             .Select((badge, index) => new BadgeDto
             {
                 Id = badge.Id,
-                Title = language == Language.Zh ? badge.NameZh : badge.NameEn,
+                Name = language == Language.Zh ? badge.NameZh : badge.NameEn,
                 IconUrl = badge.IconUrl,
                 DisplayOrder = index
             })
@@ -52,7 +52,7 @@ public class GetUserBadgesQueryHandler(BlotzTaskDbContext db, ILogger<GetUserBad
 public class BadgeDto
 {
     public int Id { get; set; }
-    public required string Title { get; set; }
+    public required string Name { get; set; }
     public required string IconUrl { get; set; }
     public int DisplayOrder { get; set; }
 }

--- a/blotztask-mobile/src/feature/badge/components/badge-card.tsx
+++ b/blotztask-mobile/src/feature/badge/components/badge-card.tsx
@@ -23,7 +23,7 @@ export function BadgeCard({ badge, transparent = false }: BadgeCardProps) {
         />
       </View>
       <Text className="text-sm font-baloo text-secondary text-center mt-2" numberOfLines={1}>
-        {badge.title}
+        {badge.name}
       </Text>
     </View>
   );

--- a/blotztask-mobile/src/feature/badge/models/badge-by-id-dto.ts
+++ b/blotztask-mobile/src/feature/badge/models/badge-by-id-dto.ts
@@ -1,6 +1,6 @@
 export interface BadgeDetailDTO {
   id: number;
-  title: string;
+  name: string;
   iconUrl: string;
   category: string;
   description: string;

--- a/blotztask-mobile/src/feature/badge/models/badge-preview-dto.ts
+++ b/blotztask-mobile/src/feature/badge/models/badge-preview-dto.ts
@@ -1,6 +1,6 @@
 export interface BadgeDTO {
   id: number;
-  title: string;
+  name: string;
   iconUrl: string;
   displayOrder: number;
 }

--- a/blotztask-mobile/src/feature/badge/screens/badge-details-screen.tsx
+++ b/blotztask-mobile/src/feature/badge/screens/badge-details-screen.tsx
@@ -53,7 +53,7 @@ export default function BadgeDetailsScreen() {
             />
 
             <Text className="text-3xl font-balooExtraBold text-secondary text-center mb-4">
-              {badgeDetail.title}
+              {badgeDetail.name}
             </Text>
 
             <Text className="text-lg font-balooBold text-gray-500 text-center leading-8 mb-7">


### PR DESCRIPTION
## Summary

Renames the badge api field from Title to Name across badge API contracts and their frontend consumers, to fix a naming inconsistency.

This is a breaking API contract change, so backend and frontend are updated together in this PR.

## Release note

none

**Status:**

- [ ] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [x] Internal only (refactor / infra / tests / CI / deps) — don't announce
