### PR TITLE
[codex] Keep AI task generation connected after network loss

### DIFF
--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
@@ -186,6 +186,7 @@ export function useAiTaskGenerator({
 
   useEffect(() => {
     let conn: signalR.HubConnection | null = null;
+    let disposed = false;
 
     signalRService
       .createConnection()
@@ -204,13 +205,38 @@ export function useAiTaskGenerator({
           if (requestStartedAtRef.current == null) return;
           setStreamedNotes((prev) => [...prev, note]);
         });
+        conn.onreconnecting((error) => {
+          if (disposed) return;
+
+          console.warn("SignalR reconnecting:", error);
+
+          if (requestStartedAtRef.current !== null) {
+            requestStartedAtRef.current = null;
+            pendingInputModeRef.current = null;
+            setTranscript(undefined);
+            setStreamedTasks([]);
+            setStreamedNotes([]);
+            setIsAiGenerating(false);
+            Toast.show({ type: "error", text1: t("errors.default") });
+          }
+        });
+        conn.onreconnected((connectionId) => {
+          if (disposed) return;
+          console.log("SignalR reconnected. Connection ID:", connectionId);
+        });
+        conn.onclose((error) => {
+          if (disposed) return;
+          console.warn("SignalR connection closed:", error);
+        });
 
         await conn.start();
+        console.log("SignalR connected. Connection ID:", conn.connectionId);
         setConnection(conn);
       })
       .catch((error) => console.error("Error connecting to SignalR:", error));
 
     return () => {
+      disposed = true;
       if (conn) {
         conn.off("ReceiveGenerationResult", generationCompleteHandler);
         conn.off("ReceiveGenerationError", generationErrorHandler);

--- a/blotztask-mobile/src/feature/ai-task-generate/services/ai-task-generator-signalr-service.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/services/ai-task-generator-signalr-service.ts
@@ -5,6 +5,7 @@ const config = {
   API_BASE_URL: process.env.EXPO_PUBLIC_URL,
 };
 const SIGNALR_HUBS_CHAT = `${config.API_BASE_URL}/ai-task-generate-chathub`;
+const RECONNECT_DELAYS_MS = [0, 2_000, 10_000, 30_000] as const;
 
 export const signalRService = {
   createConnection: async () => {
@@ -23,7 +24,10 @@ export const signalRService = {
           return token;
         },
       })
-      .withAutomaticReconnect()
+      .withAutomaticReconnect({
+        nextRetryDelayInMilliseconds: ({ previousRetryCount }) =>
+          RECONNECT_DELAYS_MS[Math.min(previousRetryCount, RECONNECT_DELAYS_MS.length - 1)],
+      })
       .build();
     return connection;
   },


### PR DESCRIPTION
## Summary

- Keep retrying the AI task generation SignalR connection with a capped 30-second backoff.
- Log connection lifecycle transitions and connection IDs.
- End interrupted generation cleanly instead of leaving the loading state stuck.
- Ignore connection callbacks after the AI page unmounts.

Refs Blotz-Org/Blotz-Task-App-Private#1481

## Release note

> AI task generation now reconnects automatically after temporary network interruptions.

**Status:**

- [x] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce

## Validation

- npm install and npx eslint . --ext .ts,.tsx,.js in blotztask-mobile/ (passes with existing warnings)
- git diff --check
- Device network interruption scenarios documented in the linked PBI