### PR TITLE
Fix collapsed note cards in AI chat

### DIFF
--- a/blotztask-mobile/src/feature/ai-task-generate/component/ai-result-row.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/component/ai-result-row.tsx
@@ -22,6 +22,8 @@ export function AiResultRow({ onDelete, onRowOpen, enabled = true, children }: P
     <ReanimatedSwipeable
       ref={swipeRef}
       enabled={enabled}
+      containerStyle={{ width: "100%" }}
+      childrenContainerStyle={{ alignItems: "center" }}
       renderRightActions={() => (
         <View className="h-full items-center justify-center pr-6">
           <ActionButton type={ActionButtonType.Delete} onPress={onDelete} />


### PR DESCRIPTION
## Summary

- make the AI result swipeable row span the available width
- keep task and note cards centered inside the swipeable container

## Root cause

The swipeable wrapper had no width constraint, so note rows could shrink to their content and collapse the percentage-width card into a narrow white pill.

## Impact

AI-generated notes now render at the intended card width while preserving swipe-to-delete behavior.

## Validation

- `npx eslint src/feature/ai-task-generate/component/ai-result-row.tsx`
- `git diff --check`

## Release note

> AI-generated note cards now display at the correct width.

**Status:**

- [x] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce