### PR TITLE
fix(ai): preserve drafts when quota is exceeded

### DIFF
--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
@@ -21,6 +21,7 @@ const ERROR_CODE_TO_I18N_KEY: Record<string, string> = {
   BlockedByContentFilter: "errors.contentFilter",
   Canceled: "errors.canceled",
   NoTasksExtracted: "errors.noTasksExtracted",
+  QuotaExceeded: "errors.quotaExceeded",
 };
 
 export function useAiTaskGenerator({
@@ -167,8 +168,10 @@ export function useAiTaskGenerator({
     requestStartedAtRef.current = null;
     const inputMode = pendingInputModeRef.current;
     pendingInputModeRef.current = null;
-    setStreamedTasks([]);
-    setStreamedNotes([]);
+    if (error.errorCode !== "QuotaExceeded") {
+      setStreamedTasks([]);
+      setStreamedNotes([]);
+    }
 
     analytics.trackAiTaskGenerationFailed({
       inputMode: inputMode ?? "unknown",

--- a/blotztask-mobile/src/i18n/locales/en/ai-task-generate.json
+++ b/blotztask-mobile/src/i18n/locales/en/ai-task-generate.json
@@ -21,6 +21,7 @@
     "contentFilter": "Your message was flagged. Please rephrase and try again.",
     "canceled": "The request was canceled.",
     "noTasksExtracted": "I couldn't find any tasks in that. Please try again.",
+    "quotaExceeded": "You've reached your AI usage limit. Your generated items have been kept.",
     "holdLonger": "Hold the mic a little longer to record.",
     "recordingFailed": "Failed to start recording. Please try again."
   },

--- a/blotztask-mobile/src/i18n/locales/zh/ai-task-generate.json
+++ b/blotztask-mobile/src/i18n/locales/zh/ai-task-generate.json
@@ -21,6 +21,7 @@
     "contentFilter": "您的消息被系统拦截，请换一种说法再试。",
     "canceled": "请求已取消。",
     "noTasksExtracted": "我没有找到任何任务，请再试一次。",
+    "quotaExceeded": "您的 AI 使用额度已达上限，已生成的内容会继续保留。",
     "holdLonger": "请长按麦克风以录音。",
     "recordingFailed": "录音启动失败，请再试一次。"
   },


### PR DESCRIPTION
## Summary

- preserve existing AI-generated task and note drafts when the backend reports `QuotaExceeded`
- show a dedicated quota-limit message in English and Chinese
- keep the existing clearing behavior for all other generation errors

## Root cause

The generation error handler cleared all streamed drafts for every error code. Quota checks happen before streaming starts, so a quota rejection erased drafts from earlier turns even though the rejected turn produced nothing.

## Validation

- `npm ci`
- `npx eslint . --ext .ts,.tsx,.js` (0 errors; existing warnings only)
- API restore, Release build, publish, and EF migration script generation
- backend test run attempted; local SQL Server Testcontainers exhausted Docker memory, so GitHub Actions remains the authoritative full-suite run

## Release note

> AI-generated drafts are now kept when you reach your AI usage limit.

**Status:**

- [x] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce
