### PR TITLE
chore(infra): remove legacy Azure Whisper config

### DIFF
--- a/blotztask-api/appsettings.json
+++ b/blotztask-api/appsettings.json
@@ -51,9 +51,6 @@
       },
       "Breakdown": {
         "DeploymentId": ""
-      },
-      "Speech": {
-        "DeploymentId": ""
       }
     }
   },

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -27,11 +27,6 @@ param taskGenerationModelName string
 param taskGenerationModelVersion string
 param taskGenerationDeploymentCapacity int
 
-param speechDeploymentName string
-param speechModelName string
-param speechModelVersion string
-param speechDeploymentCapacity int
-
 param githubRepo string // Format: org/repo (e.g., sol-wizard/Blotz-Task-App)
 param budgetAmount int
 param alertEmail string
@@ -112,7 +107,6 @@ module webAppForAPI 'modules/appService.bicep' = {
     openAiEndpoint: openAi.outputs.endpoint
     openAiTaskGenerationDeploymentId: openAi.outputs.taskGenerationDeploymentId
     openAiBreakdownDeploymentId: openAi.outputs.breakdownDeploymentId
-    openAiSpeechDeploymentId: openAi.outputs.speechDeploymentId
     logAnalyticsWorkspaceId: logAnalytics.outputs.id
     azureMonitorOpenTelemetryEnabled: azureMonitorOpenTelemetryEnabled
     enableAppServiceDiagnostics: appServiceDiagnosticsEnabled
@@ -182,10 +176,6 @@ module openAi 'modules/openAi.bicep' = {
     taskGenerationModelName: taskGenerationModelName
     taskGenerationModelVersion: taskGenerationModelVersion
     taskGenerationDeploymentCapacity: taskGenerationDeploymentCapacity
-    speechDeploymentName: speechDeploymentName
-    speechModelName: speechModelName
-    speechModelVersion: speechModelVersion
-    speechDeploymentCapacity: speechDeploymentCapacity
   }
 }
 module githubActionIdentity 'modules/identity.bicep' = {

--- a/infra/modules/appService.bicep
+++ b/infra/modules/appService.bicep
@@ -6,7 +6,6 @@ param keyVaultUri string
 param openAiEndpoint string
 param openAiTaskGenerationDeploymentId string
 param openAiBreakdownDeploymentId string
-param openAiSpeechDeploymentId string
 param logAnalyticsWorkspaceId string
 param azureMonitorOpenTelemetryEnabled bool = false
 param enableAppServiceDiagnostics bool = false
@@ -97,10 +96,6 @@ resource appService 'Microsoft.Web/sites@2022-09-01' = {
         {
           name: 'AzureOpenAI__AiModels__Breakdown__DeploymentId'
           value: openAiBreakdownDeploymentId
-        }
-        {
-          name: 'AzureOpenAI__AiModels__Speech__DeploymentId'
-          value: openAiSpeechDeploymentId
         }
         {
           name: 'ApiKeys__UserSync'

--- a/infra/modules/openAi.bicep
+++ b/infra/modules/openAi.bicep
@@ -13,11 +13,6 @@ param taskGenerationModelName string
 param taskGenerationModelVersion string
 param taskGenerationDeploymentCapacity int
 
-param speechDeploymentName string
-param speechModelName string
-param speechModelVersion string
-param speechDeploymentCapacity int
-
 resource openAiService 'Microsoft.CognitiveServices/accounts@2025-06-01' = {
   name: 'oai-${projectName}-${environment}'
   location: location
@@ -85,25 +80,6 @@ resource taskGenerationDeployment 'Microsoft.CognitiveServices/accounts/deployme
   }
 }
 
-resource speechDeployment 'Microsoft.CognitiveServices/accounts/deployments@2025-06-01' = {
-  name: speechDeploymentName
-  parent: openAiService
-  dependsOn: [taskGenerationDeployment]
-  sku: {
-    name: 'Standard'
-    capacity: speechDeploymentCapacity
-  }
-  properties: {
-    model: {
-      format: 'OpenAI'
-      name: speechModelName
-      version: speechModelVersion
-    }
-    raiPolicyName: 'Microsoft.DefaultV2'
-    versionUpgradeOption: 'OnceNewDefaultVersionAvailable'
-  }
-}
-
 module storeOpenAiKey 'keyVaultSecret.bicep' = {
   name: '${deployment().name}-store-openai-key'
   params: {
@@ -116,5 +92,4 @@ module storeOpenAiKey 'keyVaultSecret.bicep' = {
 output endpoint string = openAiService.properties.endpoint
 output taskGenerationDeploymentId string = taskGenerationDeploymentName
 output breakdownDeploymentId string = breakdownDeploymentName
-output speechDeploymentId string = speechDeploymentName
 output foundryProjectId string = foundryProject.id

--- a/infra/prod.bicepparam
+++ b/infra/prod.bicepparam
@@ -14,11 +14,6 @@ param taskGenerationModelName = 'gpt-5.4-mini'
 param taskGenerationModelVersion = '2026-03-17'
 param taskGenerationDeploymentCapacity = 130
 
-param speechDeploymentName = 'whisper'
-param speechModelName = 'whisper'
-param speechModelVersion = '001'
-param speechDeploymentCapacity = 2
-
 param githubRepo = 'sol-wizard/Blotz-Task-App'
 param budgetAmount = 40 // AUD per month for production
 param alertEmail = 'benjaminneoh2928@gmail.com'

--- a/infra/stag.bicepparam
+++ b/infra/stag.bicepparam
@@ -14,11 +14,6 @@ param taskGenerationModelName = 'gpt-5.4-mini'
 param taskGenerationModelVersion = '2026-03-17'
 param taskGenerationDeploymentCapacity = 150
 
-param speechDeploymentName = 'whisper'
-param speechModelName = 'whisper'
-param speechModelVersion = '001'
-param speechDeploymentCapacity = 1
-
 param githubRepo = 'sol-wizard/Blotz-Task-App'
 param budgetAmount = 30
 param alertEmail = 'benjaminneoh2928@gmail.com'


### PR DESCRIPTION
## Summary

- remove the unused Azure OpenAI speech deployment from the Bicep record
- remove the legacy speech deployment app setting and parameter wiring
- remove the obsolete Azure speech configuration from appsettings
- keep the active Groq speech model configuration unchanged

## Impact

This keeps the infrastructure record aligned with the current Groq-based transcription path. It does not deploy Bicep or change live Azure resources.

## Release note

> none

**Status:**

- [ ] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [x] Internal only (refactor / infra / tests / CI / deps) — don't announce

## Validation

- `az bicep build --file infra/main.bicep --stdout`
- `az bicep build-params --file infra/prod.bicepparam --stdout`
- `az bicep build-params --file infra/stag.bicepparam --stdout`
- `jq empty blotztask-api/appsettings.json`
