### PR TITLE
Track task completion, reopen, and delete in PostHog

### DIFF
--- a/blotztask-mobile/src/feature/calendar/components/task-card.tsx
+++ b/blotztask-mobile/src/feature/calendar/components/task-card.tsx
@@ -307,11 +307,19 @@ const TaskCard = ({ task, deleteTask, isDeleting, selectedDay, onOpenMode, onRow
                       recurringTaskId,
                       occurrenceDate,
                       wasDone: task.isDone,
+                      wasOverdue: isOverdue,
+                      hasDeadline: task.isDeadline,
                     });
                     return;
                   }
                   if (!hasTaskItemId(task)) return;
-                  toggleTask({ taskId: task.id, selectedDay, wasDone: task.isDone });
+                  toggleTask({
+                    taskId: task.id,
+                    selectedDay,
+                    wasDone: task.isDone,
+                    wasOverdue: isOverdue,
+                    hasDeadline: task.isDeadline,
+                  });
                   if (task.alertTime && new Date(task.alertTime) > new Date()) {
                     await cancelNotification({ notificationId: task?.notificationId });
                   }

--- a/blotztask-mobile/src/feature/calendar/hooks/useRecurringTaskMutations.ts
+++ b/blotztask-mobile/src/feature/calendar/hooks/useRecurringTaskMutations.ts
@@ -7,11 +7,14 @@ import {
 } from "@/shared/services/task-service";
 import { convertToDateTimeOffset } from "@/shared/util/convert-to-datetimeoffset";
 import { useFirework } from "@/feature/firework-animation/hooks/useFirework";
+import { analytics } from "@/shared/services/analytics";
 
 type CompleteRecurringOccurrenceArgs = {
   recurringTaskId: number;
   occurrenceDate: string;
   wasDone: boolean;
+  wasOverdue: boolean;
+  hasDeadline: boolean;
 };
 
 type MaterializeRecurringOccurrenceArgs = {
@@ -29,6 +32,15 @@ export function useRecurringTaskMutations() {
       saveRecurringOccurrence({ recurringTaskId, occurrenceDate }),
     onSuccess: (_data, variables) => {
       taskFirework.playIfCompleting(variables.wasDone);
+      if (!variables.wasDone) {
+        analytics.trackTaskCompleted({
+          taskId: variables.recurringTaskId,
+          isRecurring: true,
+          wasOverdue: variables.wasOverdue,
+          hasDeadline: variables.hasDeadline,
+          occurrenceDate: variables.occurrenceDate,
+        });
+      }
       invalidateRecurringOccurrenceQueries(queryClient, variables.occurrenceDate);
     },
   });

--- a/blotztask-mobile/src/shared/constants/posthog-events.ts
+++ b/blotztask-mobile/src/shared/constants/posthog-events.ts
@@ -8,6 +8,7 @@ export const EVENTS = {
   NOTE_CREATED: "note_created",
   TASK_COMPLETED: "task_completed",
   TASK_REOPENED: "task_reopened",
+  TASK_DELETED: "task_deleted",
 } as const;
 
 export const SCREEN_NAMES = {

--- a/blotztask-mobile/src/shared/constants/posthog-events.ts
+++ b/blotztask-mobile/src/shared/constants/posthog-events.ts
@@ -6,6 +6,8 @@ export const EVENTS = {
   BREAKDOWN_TASK: "breakdown_task",
   SCREEN_VIEWED: "screen_viewed",
   NOTE_CREATED: "note_created",
+  TASK_COMPLETED: "task_completed",
+  TASK_REOPENED: "task_reopened",
 } as const;
 
 export const SCREEN_NAMES = {

--- a/blotztask-mobile/src/shared/hooks/useTaskMutations.ts
+++ b/blotztask-mobile/src/shared/hooks/useTaskMutations.ts
@@ -24,11 +24,14 @@ import {
 import { convertToDateTimeOffset } from "../util/convert-to-datetimeoffset";
 import { TaskDetailDTO } from "../models/task-detail-dto";
 import { useFirework } from "@/feature/firework-animation/hooks/useFirework";
+import { analytics } from "../services/analytics";
 
 type ToggleTaskVariables = {
   taskId: number;
   selectedDay?: Date;
   wasDone: boolean;
+  wasOverdue: boolean;
+  hasDeadline: boolean;
 };
 
 type UpdateTaskArgs = {
@@ -112,6 +115,16 @@ const useTaskMutations = () => {
     },
     onSuccess: (_data, variables) => {
       taskFirework.playIfCompleting(variables.wasDone);
+      if (variables.wasDone) {
+        analytics.trackTaskReopened({ taskId: variables.taskId });
+      } else {
+        analytics.trackTaskCompleted({
+          taskId: variables.taskId,
+          isRecurring: false,
+          wasOverdue: variables.wasOverdue,
+          hasDeadline: variables.hasDeadline,
+        });
+      }
       queryClient.invalidateQueries({ queryKey: taskKeys.all });
     },
   });

--- a/blotztask-mobile/src/shared/hooks/useTaskMutations.ts
+++ b/blotztask-mobile/src/shared/hooks/useTaskMutations.ts
@@ -132,6 +132,12 @@ const useTaskMutations = () => {
   const deleteTaskMutation = useMutation({
     mutationFn: (task: TaskDetailDTO) => deleteTask(task.id!),
     onSuccess: (_data, task) => {
+      analytics.trackTaskDeleted({
+        taskId: task.id!,
+        isRecurring: false,
+        wasOverdue: parseISO(task.endTime).getTime() <= Date.now(),
+        hasDeadline: task.isDeadline,
+      });
       queryClient.invalidateQueries({ queryKey: taskKeys.all });
       invalidateSelectedDayTask(queryClient, task.startTime, task.endTime);
     },
@@ -140,6 +146,11 @@ const useTaskMutations = () => {
   const deleteRecurringOccurrenceMutation = useMutation({
     mutationFn: (payload: DeleteRecurringOccurrenceArgs) => deleteRecurringOccurrence(payload),
     onSuccess: async (_data, task) => {
+      analytics.trackTaskDeleted({
+        taskId: task.recurringTaskId,
+        isRecurring: true,
+        occurrenceDate: task.occurrenceDate,
+      });
       queryClient.removeQueries({ queryKey: ["virtualTaskDetail"] });
       if (!task.deleteFuture) {
         removeDeletedRecurringOccurrencesFromSelectedDayCaches(queryClient, task);

--- a/blotztask-mobile/src/shared/services/analytics.ts
+++ b/blotztask-mobile/src/shared/services/analytics.ts
@@ -149,4 +149,26 @@ export const analytics = {
   trackTaskReopened(params: { taskId: number }) {
     posthog.capture(EVENTS.TASK_REOPENED, { task_id: params.taskId });
   },
+
+  /**
+   * Fires when a user deletes a task. A high delete rate can signal low-quality
+   * AI output or users giving up on stale tasks. Shares `task_id` with the rest
+   * of the task lifecycle. `was_overdue` / `has_deadline` are only available for
+   * normal tasks (recurring deletes don't carry the full task).
+   */
+  trackTaskDeleted(params: {
+    taskId: number;
+    isRecurring: boolean;
+    wasOverdue?: boolean;
+    hasDeadline?: boolean;
+    occurrenceDate?: string;
+  }) {
+    posthog.capture(EVENTS.TASK_DELETED, {
+      task_id: params.taskId,
+      is_recurring: params.isRecurring,
+      ...(params.wasOverdue !== undefined ? { was_overdue: params.wasOverdue } : {}),
+      ...(params.hasDeadline !== undefined ? { has_deadline: params.hasDeadline } : {}),
+      ...(params.occurrenceDate ? { occurrence_date: params.occurrenceDate } : {}),
+    });
+  },
 };

--- a/blotztask-mobile/src/shared/services/analytics.ts
+++ b/blotztask-mobile/src/shared/services/analytics.ts
@@ -119,4 +119,34 @@ export const analytics = {
   trackNoteCreated(params: { source: "manual" | "ai" }) {
     posthog.capture(EVENTS.NOTE_CREATED, { source: params.source });
   },
+
+  /**
+   * Fires when a user marks a task as complete — the core value moment for a to-do app.
+   * Only fires on genuine completion, never when un-completing a task.
+   * Carries `task_id` so creation → completion can be joined in PostHog once task creation
+   * is tracked, enabling completion-rate and "do completers retain better?" analysis.
+   */
+  trackTaskCompleted(params: {
+    taskId: number;
+    isRecurring: boolean;
+    wasOverdue: boolean;
+    hasDeadline: boolean;
+    occurrenceDate?: string;
+  }) {
+    posthog.capture(EVENTS.TASK_COMPLETED, {
+      task_id: params.taskId,
+      is_recurring: params.isRecurring,
+      was_overdue: params.wasOverdue,
+      has_deadline: params.hasDeadline,
+      ...(params.occurrenceDate ? { occurrence_date: params.occurrenceDate } : {}),
+    });
+  },
+
+  /**
+   * Fires when a user un-completes a task (checks it back off).
+   * A high reopen rate can hint at accidental completions or unclear task state.
+   */
+  trackTaskReopened(params: { taskId: number }) {
+    posthog.capture(EVENTS.TASK_REOPENED, { task_id: params.taskId });
+  },
 };


### PR DESCRIPTION
## Summary

Adds two PostHog events — `task_completed`, `task_reopened`, `task_deleted` — for
normal and recurring tasks. We currently track task creation but not
completion; this adds the completion side so we can measure whether and
how users finish their tasks, and later connect creation → completion by
`task_id`. Additive only — no existing events removed, no backend/DB
change. Events fire on server-confirmed success and only on genuine
completion (same guard as the completion firework).

## Release note

> none

**Status:**

- [ ] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [x] Internal only (refactor / infra / tests / CI / deps) — don't announce
