### PR TITLE
Validate AI config at startup with the Options pattern

### DIFF
--- a/blotztask-api/Extension/AgentFrameworkServicesExtensions.cs
+++ b/blotztask-api/Extension/AgentFrameworkServicesExtensions.cs
@@ -2,6 +2,8 @@ using Azure;
 using Azure.AI.OpenAI;
 using Azure.AI.Projects;
 using Azure.Identity;
+using BlotzTask.Extension.Options;
+using Microsoft.Extensions.Options;
 using OpenAI;
 using System.ClientModel;
 
@@ -9,53 +11,51 @@ namespace BlotzTask.Extension;
 
 public static class AgentFrameworkServiceExtensions
 {
-    public class AzureAIOptions
+    public static IServiceCollection AddAgentFrameworkServices(this IServiceCollection services)
     {
-        public required string Endpoint { get; init; }
-        public required string ApiKey { get; init; }
-        public required string TaskGenerationDeploymentId { get; init; }
-        public required string BreakdownDeploymentId { get; init; }
-        public required string GroqApiKey { get; init; }
-        public required string GroqSpeechModel { get; init; }
-        public required string GroqEndpoint { get; init; }
-    }
+        services.AddOptions<AzureOpenAIOptions>()
+            .BindConfiguration(AzureOpenAIOptions.SectionName)
+            .ValidateDataAnnotations()
+            .Validate(
+                options => !string.IsNullOrWhiteSpace(options.AiModels.TaskGeneration.DeploymentId),
+                $"Missing {AzureOpenAIOptions.SectionName}:AiModels:TaskGeneration:DeploymentId")
+            .Validate(
+                options => !string.IsNullOrWhiteSpace(options.AiModels.Breakdown.DeploymentId),
+                $"Missing {AzureOpenAIOptions.SectionName}:AiModels:Breakdown:DeploymentId")
+              .Validate(
+                options => Uri.TryCreate(options.Endpoint, UriKind.Absolute, out _),
+                $"{AzureOpenAIOptions.SectionName}:Endpoint must be a valid absolute URI")
+            .ValidateOnStart();
 
-    public static IServiceCollection AddAgentFrameworkServices(
-        this IServiceCollection services, IConfiguration configuration)
-    {
-        var options = new AzureAIOptions
-        {
-            Endpoint = configuration["AzureOpenAI:Endpoint"]
-                ?? throw new InvalidOperationException("Missing AzureOpenAI:Endpoint"),
-            ApiKey = configuration["AzureOpenAI:ApiKey"]
-                ?? throw new InvalidOperationException("Missing AzureOpenAI:ApiKey"),
-            TaskGenerationDeploymentId = configuration["AzureOpenAI:AiModels:TaskGeneration:DeploymentId"]
-                ?? throw new InvalidOperationException("Missing AzureOpenAI:AiModels:TaskGeneration:DeploymentId"),
-            BreakdownDeploymentId = configuration["AzureOpenAI:AiModels:Breakdown:DeploymentId"]
-                ?? throw new InvalidOperationException("Missing AzureOpenAI:AiModels:Breakdown:DeploymentId"),
-            GroqApiKey = configuration["Groq:ApiKey"]
-                ?? throw new InvalidOperationException("Missing Groq:ApiKey"),
-            GroqSpeechModel = configuration["Groq:SpeechModel"]
-                ?? throw new InvalidOperationException("Missing Groq:SpeechModel"),
-            GroqEndpoint = configuration["Groq:Endpoint"]
-                ?? throw new InvalidOperationException("Missing Groq:Endpoint"),
-        };
+        services.AddOptions<GroqOptions>()
+            .BindConfiguration(GroqOptions.SectionName)
+            .ValidateDataAnnotations()
+            .Validate(
+                options => Uri.TryCreate(options.Endpoint, UriKind.Absolute, out _),
+                $"{GroqOptions.SectionName}:Endpoint must be a valid absolute URI")
+            .ValidateOnStart();
 
         // AIProjectClient is shared — one client, multiple deployment targets.
         // AIAgent is NOT created here because instructions are user-specific
         // (language + local time) and must be set per-session in the service layer.
         //TODO: to see whether we have a better solution
-        services.AddSingleton(options);
-        services.AddSingleton<AzureOpenAIClient>(_ =>
-            new AzureOpenAIClient(new Uri(options.Endpoint), new AzureKeyCredential(options.ApiKey)));
-        services.AddSingleton<AIProjectClient>(_ =>
-            new AIProjectClient(new Uri(options.Endpoint), new DefaultAzureCredential()));
-        services.AddSingleton(_ =>
+        services.AddSingleton<AzureOpenAIClient>(serviceProvider =>
         {
+            var options = serviceProvider.GetRequiredService<IOptions<AzureOpenAIOptions>>().Value;
+            return new AzureOpenAIClient(new Uri(options.Endpoint), new AzureKeyCredential(options.ApiKey));
+        });
+        services.AddSingleton<AIProjectClient>(serviceProvider =>
+        {
+            var options = serviceProvider.GetRequiredService<IOptions<AzureOpenAIOptions>>().Value;
+            return new AIProjectClient(new Uri(options.Endpoint), new DefaultAzureCredential());
+        });
+        services.AddSingleton(serviceProvider =>
+        {
+            var options = serviceProvider.GetRequiredService<IOptions<GroqOptions>>().Value;
             var groqClient = new OpenAIClient(
-                new ApiKeyCredential(options.GroqApiKey),
-                new OpenAIClientOptions { Endpoint = new Uri(options.GroqEndpoint) });
-            return groqClient.GetAudioClient(options.GroqSpeechModel);
+                new ApiKeyCredential(options.ApiKey),
+                new OpenAIClientOptions { Endpoint = new Uri(options.Endpoint) });
+            return groqClient.GetAudioClient(options.SpeechModel);
         });
 
         return services;

--- a/blotztask-api/Extension/Options/AzureOpenAIOptions.cs
+++ b/blotztask-api/Extension/Options/AzureOpenAIOptions.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BlotzTask.Extension.Options;
+
+public sealed class AzureOpenAIOptions
+{
+    // Must match the section name in appsettings.json. Change it here if you rename it there.
+    public const string SectionName = "AzureOpenAI";
+
+    [Required]
+    public string Endpoint { get; set; } = "";
+
+    [Required]
+    public string ApiKey { get; set; } = "";
+
+    public AiModelsOptions AiModels { get; set; } = new();
+}
+
+public sealed class AiModelsOptions
+{
+    public ModelDeploymentOptions TaskGeneration { get; set; } = new();
+
+    public ModelDeploymentOptions Breakdown { get; set; } = new();
+}
+
+public sealed class ModelDeploymentOptions
+{
+    public string DeploymentId { get; set; } = "";
+}

--- a/blotztask-api/Extension/Options/GroqOptions.cs
+++ b/blotztask-api/Extension/Options/GroqOptions.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BlotzTask.Extension.Options;
+
+public sealed class GroqOptions
+{
+    // Must match the section name in appsettings.json. Change it here if you rename it there.
+    public const string SectionName = "Groq";
+
+    [Required]
+    public string ApiKey { get; set; } = "";
+
+    [Required]
+    public string SpeechModel { get; set; } = "";
+
+    [Required]
+    public string Endpoint { get; set; } = "";
+}

--- a/blotztask-api/Modules/BreakDown/Commands/BreakdownTask.cs
+++ b/blotztask-api/Modules/BreakDown/Commands/BreakdownTask.cs
@@ -2,7 +2,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ClientModel;
 using Azure.AI.Projects;
-using BlotzTask.Extension;
+using BlotzTask.Extension.Options;
 using BlotzTask.Modules.AiUsage.Services;
 using BlotzTask.Modules.BreakDown.DTOs;
 using BlotzTask.Modules.BreakDown.Prompts;
@@ -11,6 +11,7 @@ using BlotzTask.Modules.Users.Enums;
 using BlotzTask.Modules.Users.Queries;
 using BlotzTask.Shared.Exceptions;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
 
 namespace BlotzTask.Modules.BreakDown.Commands;
 
@@ -26,11 +27,11 @@ public class BreakdownTaskCommandHandler(
     GetTaskByIdQueryHandler getTaskByIdQueryHandler,
     GetUserPreferencesQueryHandler getUserPreferencesQueryHandler,
     AIProjectClient projectClient,
-    AgentFrameworkServiceExtensions.AzureAIOptions options,
+    IOptions<AzureOpenAIOptions> options,
     ICheckAiQuotaService checkAiQuotaService,
     IRecordAiUsageService recordAiUsageService)
 {
-    private readonly string _deploymentId = options.BreakdownDeploymentId;
+    private readonly string _deploymentId = options.Value.AiModels.Breakdown.DeploymentId;
 
     public async Task<BreakdownResult> Handle(BreakdownTaskCommand command, CancellationToken ct = default)
     {

--- a/blotztask-api/Modules/ChatTaskGenerator/Services/AiChatService.cs
+++ b/blotztask-api/Modules/ChatTaskGenerator/Services/AiChatService.cs
@@ -1,13 +1,14 @@
 using System.Diagnostics;
 using System.ClientModel;
 using Azure.AI.Projects;
-using BlotzTask.Extension;
+using BlotzTask.Extension.Options;
 using BlotzTask.Modules.AiUsage.Services;
 using BlotzTask.Modules.ChatTaskGenerator.Constants;
 using BlotzTask.Modules.ChatTaskGenerator.Dtos;
 using BlotzTask.Modules.ChatTaskGenerator.Functions;
 using BlotzTask.Shared.Exceptions;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
 
 namespace BlotzTask.Modules.ChatTaskGenerator.Services;
 
@@ -20,12 +21,12 @@ public interface IAiChatService
 public class AiChatService(
     ILogger<AiChatService> logger,
     AIProjectClient projectClient,
-    AgentFrameworkServiceExtensions.AzureAIOptions options,
+    IOptions<AzureOpenAIOptions> options,
     ICheckAiQuotaService checkAiQuotaService,
     IRecordAiUsageService recordAiUsageService)
     : IAiChatService
 {
-    private readonly string _deploymentId = options.TaskGenerationDeploymentId;
+    private readonly string _deploymentId = options.Value.AiModels.TaskGeneration.DeploymentId;
 
     public async Task<AiChatContext> InitializeAsync(string preferredLanguage, TimeZoneInfo timeZone, CancellationToken ct)
     {

--- a/blotztask-api/Modules/Notes/Commands/TimeEstimate.cs
+++ b/blotztask-api/Modules/Notes/Commands/TimeEstimate.cs
@@ -1,12 +1,13 @@
 using System.ComponentModel;
 using Azure.AI.Projects;
-using BlotzTask.Extension;
+using BlotzTask.Extension.Options;
 using BlotzTask.Modules.AiUsage.Services;
 using BlotzTask.Modules.Notes.DTOs;
 using BlotzTask.Modules.Notes.Prompts;
 using BlotzTask.Modules.Users.Enums;
 using BlotzTask.Modules.Users.Queries;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
 
 namespace BlotzTask.Modules.Notes.Commands;
 
@@ -28,11 +29,11 @@ public class TimeEstimateCommandHandler(
     ILogger<TimeEstimateCommandHandler> logger,
     GetUserPreferencesQueryHandler getUserPreferencesQueryHandler,
     AIProjectClient projectClient,
-    AgentFrameworkServiceExtensions.AzureAIOptions options,
+    IOptions<AzureOpenAIOptions> options,
     ICheckAiQuotaService checkAiQuotaService,
     IRecordAiUsageService recordAiUsageService)
 {
-    private readonly string _deploymentId = options.BreakdownDeploymentId;
+    private readonly string _deploymentId = options.Value.AiModels.Breakdown.DeploymentId;
 
     public async Task<AITimeEstimationResult?> Handle(NoteTimeEstimationRequest request, CancellationToken ct = default)
     {

--- a/blotztask-api/Modules/Reviews/Commands/GenerateReview.cs
+++ b/blotztask-api/Modules/Reviews/Commands/GenerateReview.cs
@@ -2,7 +2,7 @@ using System.ClientModel;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
 using Azure.AI.OpenAI;
-using BlotzTask.Extension;
+using BlotzTask.Extension.Options;
 using BlotzTask.Infrastructure.Data;
 using BlotzTask.Modules.AiUsage.Services;
 using BlotzTask.Modules.Reviews.Domain;
@@ -12,6 +12,7 @@ using BlotzTask.Modules.Reviews.Prompts;
 using BlotzTask.Modules.Users.Enums;
 using BlotzTask.Shared.Exceptions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using OpenAI.Chat;
 
 namespace BlotzTask.Modules.Reviews.Commands;
@@ -34,7 +35,7 @@ public class GenerateReviewCommand
 public class GenerateReviewCommandHandler(
     BlotzTaskDbContext db,
     AzureOpenAIClient azureOpenAIClient,
-    AgentFrameworkServiceExtensions.AzureAIOptions aiOptions,
+    IOptions<AzureOpenAIOptions> aiOptions,
     ICheckAiQuotaService checkAiQuotaService,
     IRecordAiUsageService recordAiUsageService,
     ILogger<GenerateReviewCommandHandler> logger)
@@ -43,7 +44,7 @@ public class GenerateReviewCommandHandler(
     // o-series reasoning models — if Breakdown points at a non-reasoning model (e.g. GPT-4o),
     // the option is ignored. Revisit once we decide whether review needs its own
     // deployment (likely a reasoning model for better reflection quality).
-    private readonly string _deploymentId = aiOptions.BreakdownDeploymentId;
+    private readonly string _deploymentId = aiOptions.Value.AiModels.Breakdown.DeploymentId;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/blotztask-api/Program.cs
+++ b/blotztask-api/Program.cs
@@ -43,7 +43,7 @@ builder.Services.AddUserModule(builder.Configuration);
 builder.Services.AddAppVersionModule();
 
 // External integrations
-builder.Services.AddAgentFrameworkServices(builder.Configuration);
+builder.Services.AddAgentFrameworkServices();
 
 var app = builder.Build();
 

--- a/infra/modules/appService.bicep
+++ b/infra/modules/appService.bicep
@@ -106,6 +106,18 @@ resource appService 'Microsoft.Web/sites@2022-09-01' = {
           value: '@Microsoft.KeyVault(SecretUri=${normalizedKeyVaultUri}secrets/azureopenai-apikey/)'
         }
         {
+          name: 'Groq__Endpoint'
+          value: 'https://api.groq.com/openai/v1'
+        }
+        {
+          name: 'Groq__SpeechModel'
+          value: 'whisper-large-v3-turbo'
+        }
+        {
+          name: 'Groq__ApiKey'
+          value: '@Microsoft.KeyVault(SecretUri=${normalizedKeyVaultUri}secrets/groq-apikey/)'
+        }
+        {
           name: 'ConnectionStrings__DefaultConnection'
           value: '@Microsoft.KeyVault(SecretUri=${normalizedKeyVaultUri}secrets/sql-connection-string/)'
         }


### PR DESCRIPTION
## Summary

- Replace the hand-rolled AI config reading in `AddAgentFrameworkServices` with strongly-typed `AzureOpenAIOptions` + `GroqOptions`, bound and validated at startup (`ValidateDataAnnotations` + `ValidateOnStart`).
- **Bug fix:** a blank `Groq:ApiKey` slipped past the null-only `??` guard and threw inside the `AudioClient` factory on every chat hub connection. Empty/missing values now fail fast at boot, naming the setting, instead of a confusing SignalR error later.
- Four AI handlers now inject `IOptions<T>` instead of the old `AzureAIOptions` singleton.
- Add Groq settings to `appService.bicep` (Endpoint + SpeechModel inline; ApiKey via Key Vault reference).

⚠️ **Deploy dependency:** a `groq-apikey` secret must exist in Key Vault (staging + prod) before this ships, or startup validation will block boot.

## Release note

> none

**Status:**

- [ ] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [x] Internal only (refactor / infra / tests / CI / deps) — don't announce
