### PR TITLE
Add task_created event to track task creation in PostHog

### DIFF
--- a/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
@@ -136,10 +136,21 @@ export default function AiTaskSheetScreen() {
     if (isAdding || isNoteCreating || isCreatingRecurringTask) return;
 
     const results = await Promise.allSettled([
-      ...displayTasks.map((task) => addTaskAsync(convertAiTaskToTaskUpsertDTO(task))),
-      ...displayRecurringTasks.map((task) =>
-        createRecurringTaskAsync(mapRecurringToCreateDTO(task)),
-      ),
+      ...displayTasks.map(async (task) => {
+        // Fire per successful task, not behind the all-succeed gate below, so a partial
+        // failure still records the tasks that did land.
+        const taskId = await addTaskAsync(convertAiTaskToTaskUpsertDTO(task));
+        analytics.trackTaskCreated({ taskId, source: "ai", isRecurring: false, hasDeadline: false });
+      }),
+      ...displayRecurringTasks.map(async (task) => {
+        const { recurringTaskId } = await createRecurringTaskAsync(mapRecurringToCreateDTO(task));
+        analytics.trackTaskCreated({
+          taskId: recurringTaskId,
+          source: "ai",
+          isRecurring: true,
+          hasDeadline: false,
+        });
+      }),
       ...displayNotes.map((n) => createNoteAsync({ text: n.text, isPersistent: false })),
     ]);
 

--- a/blotztask-mobile/src/feature/task-add-edit/screens/task-create-screen.tsx
+++ b/blotztask-mobile/src/feature/task-add-edit/screens/task-create-screen.tsx
@@ -22,8 +22,14 @@ export default function TaskCreateScreen() {
       if (!recurringTask) return;
 
       createRecurringTask(recurringTask, {
-        onSuccess: () => {
+        onSuccess: (result) => {
           analytics.trackManualTaskCreated();
+          analytics.trackTaskCreated({
+            taskId: result.recurringTaskId,
+            source: "manual",
+            isRecurring: true,
+            hasDeadline: recurringTask.isDeadline ?? false,
+          });
           router.back();
           Toast.show({ type: "warning", text1: t("success.taskCreated") });
         },
@@ -32,8 +38,14 @@ export default function TaskCreateScreen() {
     }
 
     addTask(submitTask, {
-      onSuccess: () => {
+      onSuccess: (taskId) => {
         analytics.trackManualTaskCreated();
+        analytics.trackTaskCreated({
+          taskId,
+          source: "manual",
+          isRecurring: false,
+          hasDeadline: submitTask.isDeadline ?? false,
+        });
         router.back();
         Toast.show({ type: "success", text1: t("success.taskCreated") });
       },

--- a/blotztask-mobile/src/shared/constants/posthog-events.ts
+++ b/blotztask-mobile/src/shared/constants/posthog-events.ts
@@ -6,6 +6,7 @@ export const EVENTS = {
   BREAKDOWN_TASK: "breakdown_task",
   SCREEN_VIEWED: "screen_viewed",
   NOTE_CREATED: "note_created",
+  TASK_CREATED: "task_created",
   TASK_COMPLETED: "task_completed",
   TASK_REOPENED: "task_reopened",
   TASK_DELETED: "task_deleted",
@@ -15,6 +16,9 @@ export const SCREEN_NAMES = {
   NOTES: "Notes",
   GASHAPON_MACHINE: "GashaponMachine",
 } as const;
+
+/** How a task was created. `manual` = task form, `ai` = AI generation sheet. */
+export type TaskSource = "manual" | "ai";
 
 export type AiTaskOutcome = "accepted" | "rejected" | "abandoned";
 export type AiTaskInputMode = "voice" | "text";

--- a/blotztask-mobile/src/shared/services/analytics.ts
+++ b/blotztask-mobile/src/shared/services/analytics.ts
@@ -7,6 +7,7 @@ import {
   type AiTaskGenerationTurn,
   type AiTaskInputMode,
   type AiTaskOutcome,
+  type TaskSource,
 } from "@/shared/constants/posthog-events";
 
 type ScreenName = (typeof SCREEN_NAMES)[keyof typeof SCREEN_NAMES];
@@ -118,6 +119,27 @@ export const analytics = {
 
   trackNoteCreated(params: { source: "manual" | "ai" }) {
     posthog.capture(EVENTS.NOTE_CREATED, { source: params.source });
+  },
+
+  /**
+   * Fires when a task is created — the counterpart to the completion events, carrying the same
+   * `task_id` so created → completed can be joined in PostHog. `source` separates manual vs AI
+   * creation. Recurring tasks fire this once per series (`task_id` = `recurringTaskId`), while
+   * `task_completed` fires per occurrence, so filter `is_recurring` when computing a completion
+   * rate. Preset tasks are seeded server-side and never fire this, so they are excluded naturally.
+   */
+  trackTaskCreated(params: {
+    taskId: number;
+    source: TaskSource;
+    isRecurring: boolean;
+    hasDeadline: boolean;
+  }) {
+    posthog.capture(EVENTS.TASK_CREATED, {
+      task_id: params.taskId,
+      source: params.source,
+      is_recurring: params.isRecurring,
+      has_deadline: params.hasDeadline,
+    });
   },
 
   /**


### PR DESCRIPTION
## Summary

Adds a unified `task_created` PostHog event so task creation can be joined to the existing completion events (`task_completed` / `task_reopened` / `task_deleted`) by `task_id`.

- New `task_created` with `source` (`manual` / `ai`), `task_id`, `is_recurring`, `has_deadline`.
- Fired at the two creation call sites: the manual task form and the AI generation sheet. The AI path fires per successful task, not behind the batch all-succeed gate.
- Recurring uses `recurringTaskId` as `task_id`, matching the recurring completion event so created → completed joins.
- Legacy `create_task_manually` still fires unchanged (trend continuity).

Unlocks completion-rate and manual-vs-AI breakdowns in PostHog; preset tasks are seeded server-side and never fire this, so they drop out of the join naturally.

## Release note

> none

**Status:**

- [ ] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [x] Internal only (refactor / infra / tests / CI / deps) — don't announce
