### PR TITLE
mobile UI fixes

### DIFF
--- a/blotztask-mobile/src/feature/calendar/util/format-date-range.ts
+++ b/blotztask-mobile/src/feature/calendar/util/format-date-range.ts
@@ -17,5 +17,10 @@ export const formatDateRange = ({
     if (isSameDay(singleDate, selectedDate)) return "";
     return format(singleDate, formatToken);
   }
-  return `${format(new Date(startTime), formatToken)} - ${format(new Date(endTime), formatToken)}`;
+
+  const startDate = new Date(startTime);
+  const endDate = new Date(endTime);
+  if (isSameDay(startDate, endDate)) return format(startDate, formatToken);
+
+  return `${format(startDate, formatToken)} - ${format(endDate, formatToken)}`;
 };

--- a/blotztask-mobile/src/feature/task-add-edit/components/segment-toggle.tsx
+++ b/blotztask-mobile/src/feature/task-add-edit/components/segment-toggle.tsx
@@ -43,7 +43,7 @@ export function SegmentToggle({ value, setValue }: Props) {
     >
       <Animated.View
         className="absolute bg-white rounded-xl h-10 shadow-sm shadow-gray-400"
-        style={[tabAnimatedStyle, { width: tabWidth }]}
+        style={[tabAnimatedStyle, { width: tabWidth, left: 4 }]}
       />
       <AnimatedPressable
         className={`flex-1 justify-center items-center py-2 px-2 rounded-xl `}

--- a/blotztask-mobile/src/feature/task-add-edit/components/segment-toggle.tsx
+++ b/blotztask-mobile/src/feature/task-add-edit/components/segment-toggle.tsx
@@ -12,13 +12,11 @@ type Props = {
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
-const CONTAINER_PADDING = 4;
-const MAX_CONTAINER_WIDTH = 200;
-
 export function SegmentToggle({ value, setValue }: Props) {
   const { t } = useTranslation("tasks");
-  const [containerWidth, setContainerWidth] = React.useState(MAX_CONTAINER_WIDTH);
-  const tabWidth = (containerWidth - CONTAINER_PADDING * 2) / 2;
+  // 200 and 4 mirror `max-w-[200px]` and `p-1` on the container below — change both together.
+  const [containerWidth, setContainerWidth] = React.useState(200);
+  const tabWidth = (containerWidth - 4 * 2) / 2;
   const tabPositionX = useSharedValue(value === SegmentButtonValue.Reminder ? 0 : tabWidth);
   const isInitialMount = React.useRef(true);
   React.useEffect(() => {

--- a/blotztask-mobile/src/feature/task-add-edit/components/segment-toggle.tsx
+++ b/blotztask-mobile/src/feature/task-add-edit/components/segment-toggle.tsx
@@ -12,10 +12,14 @@ type Props = {
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
+const CONTAINER_PADDING = 4;
+const MAX_CONTAINER_WIDTH = 200;
+
 export function SegmentToggle({ value, setValue }: Props) {
   const { t } = useTranslation("tasks");
-  const tabPositionX = useSharedValue(value === SegmentButtonValue.Reminder ? 0 : 224 / 2);
-  const [containerWidth, setContainerWidth] = React.useState(224);
+  const [containerWidth, setContainerWidth] = React.useState(MAX_CONTAINER_WIDTH);
+  const tabWidth = (containerWidth - CONTAINER_PADDING * 2) / 2;
+  const tabPositionX = useSharedValue(value === SegmentButtonValue.Reminder ? 0 : tabWidth);
   const isInitialMount = React.useRef(true);
   React.useEffect(() => {
     if (containerWidth > 0) {
@@ -25,7 +29,6 @@ export function SegmentToggle({ value, setValue }: Props) {
   }, [value, containerWidth]);
 
   const onTabMovingAnimation = (index: number, animate: boolean = true) => {
-    const tabWidth = containerWidth / 2;
     const target = tabWidth * index;
     tabPositionX.value = animate ? withTiming(target, { duration: 200 }) : target;
   };
@@ -36,22 +39,23 @@ export function SegmentToggle({ value, setValue }: Props) {
 
   return (
     <Animated.View
-      className="flex-row bg-[#F4F6FA] p-1 rounded-xl mb-6 w-56 items-center"
+      className="flex-row bg-[#F4F6FA] p-1 rounded-xl mb-6 w-full max-w-[200px] items-center"
       layout={MotionAnimations.layout}
       onLayout={(e) => setContainerWidth(e.nativeEvent.layout.width)}
     >
       <Animated.View
-        className="absolute bg-white rounded-xl w-28 h-10 shadow-sm shadow-gray-400"
-        style={tabAnimatedStyle}
+        className="absolute bg-white rounded-xl h-10 shadow-sm shadow-gray-400"
+        style={[tabAnimatedStyle, { width: tabWidth }]}
       />
       <AnimatedPressable
-        className={`flex-1 justify-center items-center py-2 px-3 rounded-xl `}
+        className={`flex-1 justify-center items-center py-2 px-2 rounded-xl `}
         onPress={() => {
           setValue(SegmentButtonValue.Reminder);
           onTabMovingAnimation(0);
         }}
       >
         <Text
+          numberOfLines={1}
           className={`text-[15px] font-semibold ${
             value === SegmentButtonValue.Reminder ? "text-[#1A2433]" : "text-[#6B768A]"
           }`}
@@ -62,13 +66,14 @@ export function SegmentToggle({ value, setValue }: Props) {
 
       {/* Event tab */}
       <AnimatedPressable
-        className={`flex-1 justify-center items-center py-2 px-3 rounded-xl`}
+        className={`flex-1 justify-center items-center py-2 px-2 rounded-xl`}
         onPress={() => {
           setValue(SegmentButtonValue.Event);
           onTabMovingAnimation(1);
         }}
       >
         <Text
+          numberOfLines={1}
           className={`text-[15px] font-semibold ${
             value === SegmentButtonValue.Event ? "text-[#1A2433]" : "text-[#6B768A]"
           }`}

--- a/blotztask-mobile/src/shared/components/animated-dropdown.tsx
+++ b/blotztask-mobile/src/shared/components/animated-dropdown.tsx
@@ -8,8 +8,6 @@ import { AnimatedChevron } from "./chevron";
 import { FormDivider } from "./form-divider";
 
 const PANEL_GAP = 6;
-
-const PANEL_VERTICAL_PADDING = 16;
 const SCREEN_EDGE_MARGIN = 8;
 
 export type DropdownOption<T> = {
@@ -67,6 +65,8 @@ export function AnimatedDropdown<T>({
   const foundOption = options.find((option) => option.value === value);
   const selectedLabel = foundOption?.label ?? placeholder;
 
+  const visibleCount = Math.min(options.length, maxVisibleItems);
+
   const openDropdown = (ref: View | null) => {
     if (!ref?.measureInWindow) {
       setOpen(true);
@@ -89,29 +89,15 @@ export function AnimatedDropdown<T>({
   };
 
   const anchorTop = anchor?.y ?? 0;
-  const anchorHeight = anchor?.h ?? 0;
+  const panelTopBelow = anchorTop + (anchor?.h ?? 0) + PANEL_GAP;
+  // + 16 mirrors the panel's `py-2` below
+  const panelHeight = visibleCount * itemHeight + 16;
 
-  const topLimit = SCREEN_EDGE_MARGIN;
-  const bottomLimit = windowHeight - SCREEN_EDGE_MARGIN;
-  const spaceBelow = bottomLimit - (anchorTop + anchorHeight + PANEL_GAP);
-  const spaceAbove = anchorTop - PANEL_GAP - topLimit;
-
-  const preferredListHeight = Math.min(options.length, maxVisibleItems) * itemHeight;
-  const dropUp =
-    spaceBelow < preferredListHeight + PANEL_VERTICAL_PADDING && spaceAbove > spaceBelow;
-
-  // Shrink the list rather than letting the panel run off-screen; the FlatList scrolls.
-  const availableHeight = Math.max(
-    dropUp ? spaceAbove : spaceBelow,
-    itemHeight + PANEL_VERTICAL_PADDING,
-  );
-  const listHeight = Math.min(preferredListHeight, availableHeight - PANEL_VERTICAL_PADDING);
-  const panelHeight = listHeight + PANEL_VERTICAL_PADDING;
+  // Flip above the trigger when the panel would run past the bottom of the screen.
+  const dropUp = panelTopBelow + panelHeight > windowHeight - SCREEN_EDGE_MARGIN;
 
   const panelLeft = anchor?.x ?? 0;
-  const panelTop = dropUp
-    ? Math.max(topLimit, anchorTop - PANEL_GAP - panelHeight)
-    : Math.min(anchorTop + anchorHeight + PANEL_GAP, bottomLimit - panelHeight);
+  const panelTop = dropUp ? anchorTop - PANEL_GAP - panelHeight : panelTopBelow;
   const panelWidth = Math.max(minWidth, anchor?.w ?? minWidth);
 
   return (
@@ -156,7 +142,7 @@ export function AnimatedDropdown<T>({
                 data={options}
                 keyExtractor={(item, idx) => `${item.label}-${idx}`}
                 bounces={false}
-                style={{ maxHeight: listHeight }}
+                style={{ maxHeight: visibleCount * itemHeight }}
                 renderItem={({ item }) => {
                   const selected = item.value === value;
                   return (

--- a/blotztask-mobile/src/shared/components/animated-dropdown.tsx
+++ b/blotztask-mobile/src/shared/components/animated-dropdown.tsx
@@ -7,9 +7,6 @@ import Ionicons from "@react-native-vector-icons/ionicons/static";
 import { AnimatedChevron } from "./chevron";
 import { FormDivider } from "./form-divider";
 
-const PANEL_GAP = 6;
-const SCREEN_EDGE_MARGIN = 8;
-
 export type DropdownOption<T> = {
   label: string;
   value: T;
@@ -88,16 +85,16 @@ export function AnimatedDropdown<T>({
     closeDropdown();
   };
 
+  // 6 is the gap between trigger and panel; 16 mirrors the panel's `py-2` below.
   const anchorTop = anchor?.y ?? 0;
-  const panelTopBelow = anchorTop + (anchor?.h ?? 0) + PANEL_GAP;
-  // + 16 mirrors the panel's `py-2` below
+  const panelTopBelow = anchorTop + (anchor?.h ?? 0) + 6;
   const panelHeight = visibleCount * itemHeight + 16;
 
   // Flip above the trigger when the panel would run past the bottom of the screen.
-  const dropUp = panelTopBelow + panelHeight > windowHeight - SCREEN_EDGE_MARGIN;
+  const dropUp = panelTopBelow + panelHeight > windowHeight - 8;
 
   const panelLeft = anchor?.x ?? 0;
-  const panelTop = dropUp ? anchorTop - PANEL_GAP - panelHeight : panelTopBelow;
+  const panelTop = dropUp ? anchorTop - 6 - panelHeight : panelTopBelow;
   const panelWidth = Math.max(minWidth, anchor?.w ?? minWidth);
 
   return (

--- a/blotztask-mobile/src/shared/components/animated-dropdown.tsx
+++ b/blotztask-mobile/src/shared/components/animated-dropdown.tsx
@@ -1,11 +1,16 @@
 import React, { useEffect, useState } from "react";
-import { Pressable, Text, View, FlatList } from "react-native";
+import { Pressable, Text, View, FlatList, useWindowDimensions } from "react-native";
 import Animated, { Easing, useSharedValue, withTiming } from "react-native-reanimated";
 import Modal from "react-native-modal";
 import Ionicons from "@react-native-vector-icons/ionicons/static";
 
 import { AnimatedChevron } from "./chevron";
 import { FormDivider } from "./form-divider";
+
+const PANEL_GAP = 6;
+
+const PANEL_VERTICAL_PADDING = 16;
+const SCREEN_EDGE_MARGIN = 8;
 
 export type DropdownOption<T> = {
   label: string;
@@ -47,6 +52,8 @@ export function AnimatedDropdown<T>({
   const [open, setOpen] = useState(false);
   const [anchor, setAnchor] = useState<{ x: number; y: number; w: number; h: number } | null>(null);
 
+  const { height: windowHeight } = useWindowDimensions();
+
   // animation progress: 0 -> closed, 1 -> open
   const animationProgress = useSharedValue(0);
 
@@ -59,8 +66,6 @@ export function AnimatedDropdown<T>({
 
   const foundOption = options.find((option) => option.value === value);
   const selectedLabel = foundOption?.label ?? placeholder;
-
-  const visibleCount = Math.min(options.length, maxVisibleItems);
 
   const openDropdown = (ref: View | null) => {
     if (!ref?.measureInWindow) {
@@ -83,9 +88,30 @@ export function AnimatedDropdown<T>({
     closeDropdown();
   };
 
-  // Position panel under trigger
+  const anchorTop = anchor?.y ?? 0;
+  const anchorHeight = anchor?.h ?? 0;
+
+  const topLimit = SCREEN_EDGE_MARGIN;
+  const bottomLimit = windowHeight - SCREEN_EDGE_MARGIN;
+  const spaceBelow = bottomLimit - (anchorTop + anchorHeight + PANEL_GAP);
+  const spaceAbove = anchorTop - PANEL_GAP - topLimit;
+
+  const preferredListHeight = Math.min(options.length, maxVisibleItems) * itemHeight;
+  const dropUp =
+    spaceBelow < preferredListHeight + PANEL_VERTICAL_PADDING && spaceAbove > spaceBelow;
+
+  // Shrink the list rather than letting the panel run off-screen; the FlatList scrolls.
+  const availableHeight = Math.max(
+    dropUp ? spaceAbove : spaceBelow,
+    itemHeight + PANEL_VERTICAL_PADDING,
+  );
+  const listHeight = Math.min(preferredListHeight, availableHeight - PANEL_VERTICAL_PADDING);
+  const panelHeight = listHeight + PANEL_VERTICAL_PADDING;
+
   const panelLeft = anchor?.x ?? 0;
-  const panelTop = (anchor?.y ?? 0) + (anchor?.h ?? 0) + 6;
+  const panelTop = dropUp
+    ? Math.max(topLimit, anchorTop - PANEL_GAP - panelHeight)
+    : Math.min(anchorTop + anchorHeight + PANEL_GAP, bottomLimit - panelHeight);
   const panelWidth = Math.max(minWidth, anchor?.w ?? minWidth);
 
   return (
@@ -130,7 +156,7 @@ export function AnimatedDropdown<T>({
                 data={options}
                 keyExtractor={(item, idx) => `${item.label}-${idx}`}
                 bounces={false}
-                style={{ maxHeight: visibleCount * itemHeight }}
+                style={{ maxHeight: listHeight }}
                 renderItem={({ item }) => {
                   const selected = item.value === value;
                   return (


### PR DESCRIPTION
## Summary

Alert dropdown clipped at screen bottom：Check if there is enough space below; if not, expand upwards
Add-to-Task toggle cramped：Reduce the size of the background frame and set it to auto-scale
Same-day task shows duplicated date：Events on the same day will only display the date once.

## Release note

none


**Status:**

- [x] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce
