### PR TITLE
Add PostHog events for Gashapon, Pomodoro, Badges, and Review generation

### DIFF
--- a/blotztask-mobile/src/feature/badge/components/badge-achievement-modal.tsx
+++ b/blotztask-mobile/src/feature/badge/components/badge-achievement-modal.tsx
@@ -38,7 +38,7 @@ export function BadgeAchievementModal({ badge, onDismiss }: BadgeAchievementModa
     Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
     rewardSound.seekTo(0);
     rewardSound.play();
-    analytics.trackBadgeUnlocked();
+    analytics.trackBadgeUnlocked({ badgeId });
   }, [badgeId, rewardSound]);
 
   if (!badge) return null;

--- a/blotztask-mobile/src/feature/badge/components/badge-achievement-modal.tsx
+++ b/blotztask-mobile/src/feature/badge/components/badge-achievement-modal.tsx
@@ -13,6 +13,7 @@ import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Modal, Pressable, StyleSheet, Text, View } from "react-native";
 import { useRouter } from "expo-router";
+import { analytics } from "@/shared/services/analytics";
 
 interface BadgeAchievementModalProps {
   badge?: BadgeNotificationDTO;
@@ -37,6 +38,7 @@ export function BadgeAchievementModal({ badge, onDismiss }: BadgeAchievementModa
     Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
     rewardSound.seekTo(0);
     rewardSound.play();
+    analytics.trackBadgeUnlocked();
   }, [badgeId, rewardSound]);
 
   if (!badge) return null;

--- a/blotztask-mobile/src/feature/gashapon-machine/screens/gashapon-machine-screen.tsx
+++ b/blotztask-mobile/src/feature/gashapon-machine/screens/gashapon-machine-screen.tsx
@@ -59,6 +59,7 @@ export default function GashaponMachineScreen() {
 
   const handleStarDropped = (starIndex: number) => {
     const droppedNote = limitedNotes[starIndex];
+    analytics.trackGashaponSpin();
     setRandomTask(droppedNote);
     setDroppedStarIcon(getStarIconAsBefore(droppedNote?.id ?? starIndex));
     setDropStarTrigger((prev) => prev + 1);

--- a/blotztask-mobile/src/feature/pomodoro/hooks/usePomodoroTimer.ts
+++ b/blotztask-mobile/src/feature/pomodoro/hooks/usePomodoroTimer.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { PomodoroSoundscapeType } from "../utils/pomodoro-setting";
 import { useSoundscapeStore } from "./useSoundscapeStore";
+import { analytics } from "@/shared/services/analytics";
 
 interface PomodoroSession {
   taskId: string;
@@ -51,6 +52,7 @@ export const usePomodoroTimer = create<PomodoroTimerState>((set, get) => ({
         durationSeconds: durationMinutes * 60,
       },
     });
+    analytics.trackPomodoroStarted();
     pomodoroClock = setInterval(() => get()._tick(), 1000);
     const sound = useSoundscapeStore.getState();
     void sound.playSoundscape(soundscape);

--- a/blotztask-mobile/src/feature/pomodoro/hooks/usePomodoroTimer.ts
+++ b/blotztask-mobile/src/feature/pomodoro/hooks/usePomodoroTimer.ts
@@ -52,7 +52,7 @@ export const usePomodoroTimer = create<PomodoroTimerState>((set, get) => ({
         durationSeconds: durationMinutes * 60,
       },
     });
-    analytics.trackPomodoroStarted();
+    analytics.trackPomodoroStarted({ isCountdown, durationMinutes });
     pomodoroClock = setInterval(() => get()._tick(), 1000);
     const sound = useSoundscapeStore.getState();
     void sound.playSoundscape(soundscape);

--- a/blotztask-mobile/src/feature/review/hooks/useReviewReport.ts
+++ b/blotztask-mobile/src/feature/review/hooks/useReviewReport.ts
@@ -3,14 +3,9 @@ import { isAxiosError } from "axios";
 import Toast from "react-native-toast-message";
 import { useTranslation } from "react-i18next";
 import { reviewKeys } from "@/shared/constants/query-key-factory";
-import {
-  fetchReview,
-  generateReview,
-} from "@/feature/review/services/review-service";
-import {
-  ReviewPeriodType,
-  ReviewReportDTO,
-} from "@/feature/review/models/review-dto";
+import { fetchReview, generateReview } from "@/feature/review/services/review-service";
+import { ReviewPeriodType, ReviewReportDTO } from "@/feature/review/models/review-dto";
+import { analytics } from "@/shared/services/analytics";
 
 // anchorDate: any date inside the period ("YYYY-MM-DD"); the backend snaps it to the
 // canonical start. Callers normalize to the period start so the cache key is stable.
@@ -30,6 +25,7 @@ export function useReview(periodType: ReviewPeriodType, anchorDate: string, enab
     mutationFn: () => generateReview(periodType, anchorDate),
     onSuccess: (data) => {
       queryClient.setQueryData(queryKey, data);
+      analytics.trackReviewGenerated({ period: periodType });
     },
     onError: (error) => {
       const quotaExceeded = isAxiosError(error) && error.response?.status === 429;

--- a/blotztask-mobile/src/shared/constants/posthog-events.ts
+++ b/blotztask-mobile/src/shared/constants/posthog-events.ts
@@ -15,6 +15,10 @@ export const EVENTS = {
   TASK_COMPLETED: "task_completed",
   TASK_REOPENED: "task_reopened",
   TASK_DELETED: "task_deleted",
+  GASHAPON_SPIN: "gashapon_spin",
+  POMODORO_STARTED: "pomodoro_started",
+  BADGE_UNLOCKED: "badge_unlocked",
+  REVIEW_GENERATED: "review_generated",
 } as const;
 
 export const SCREEN_NAMES = {

--- a/blotztask-mobile/src/shared/services/analytics.ts
+++ b/blotztask-mobile/src/shared/services/analytics.ts
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import { ReviewPeriodType } from "@/feature/review/models/review-dto";
 import posthog from "@/shared/constants/posthog-client";
 import {
   EVENTS,
@@ -243,5 +244,21 @@ export const analytics = {
       ...(params.hasDeadline !== undefined ? { has_deadline: params.hasDeadline } : {}),
       ...(params.occurrenceDate ? { occurrence_date: params.occurrenceDate } : {}),
     });
+  },
+
+  trackGashaponSpin() {
+    posthog.capture(EVENTS.GASHAPON_SPIN);
+  },
+
+  trackPomodoroStarted() {
+    posthog.capture(EVENTS.POMODORO_STARTED);
+  },
+
+  trackBadgeUnlocked() {
+    posthog.capture(EVENTS.BADGE_UNLOCKED);
+  },
+
+  trackReviewGenerated(params: { period: ReviewPeriodType }) {
+    posthog.capture(EVENTS.REVIEW_GENERATED, { period: params.period });
   },
 };

--- a/blotztask-mobile/src/shared/services/analytics.ts
+++ b/blotztask-mobile/src/shared/services/analytics.ts
@@ -250,12 +250,15 @@ export const analytics = {
     posthog.capture(EVENTS.GASHAPON_SPIN);
   },
 
-  trackPomodoroStarted() {
-    posthog.capture(EVENTS.POMODORO_STARTED);
+  trackPomodoroStarted(params: { isCountdown: boolean; durationMinutes: number }) {
+    posthog.capture(EVENTS.POMODORO_STARTED, {
+      is_countdown: params.isCountdown,
+      duration_minutes: params.durationMinutes,
+    });
   },
 
-  trackBadgeUnlocked() {
-    posthog.capture(EVENTS.BADGE_UNLOCKED);
+  trackBadgeUnlocked(params: { badgeId: number }) {
+    posthog.capture(EVENTS.BADGE_UNLOCKED, { badge_id: params.badgeId });
   },
 
   trackReviewGenerated(params: { period: ReviewPeriodType }) {


### PR DESCRIPTION
## Summary

Adds PostHog `capture` calls for four features that had no usage tracking:
Gashapon spins, Pomodoro session starts, badge unlocks, and weekly/monthly
review generation (tagged with a `period` property). Lets each be measured
for Unique Users and Frequency, continuing the feature-usage tracking work
already on `main`.

## Release note

> none

**Status:**

- [ ] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [x] Internal only (refactor / infra / tests / CI / deps) — don't announce
