### PR TITLE
Fix badge detail sharing and achievement title alignment

### DIFF
--- a/blotztask-api/Modules/Badges/Queries/GetBadgeById.cs
+++ b/blotztask-api/Modules/Badges/Queries/GetBadgeById.cs
@@ -19,19 +19,27 @@ public class GetBadgeByIdQueryHandler(BlotzTaskDbContext db, ILogger<GetBadgeByI
 
         var preference = await db.UserPreferences.FindAsync(query.UserId, ct);
         var language = preference?.PreferredLanguage ?? Language.En;
-        var badge = await db.Badges.FindAsync(query.BadgeId, ct);
 
-        if (badge == null)
-            throw new NotFoundException($"Badge with ID {query.BadgeId} not found.");
+        // Only badges the user has actually earned are returned, so the obtained date is always available.
+        var earnedBadge = await db.UserBadges
+            .Where(ub => ub.UserId == query.UserId && ub.BadgeId == query.BadgeId)
+            .Join(db.Badges,
+                ub => ub.BadgeId,
+                badge => badge.Id,
+                (ub, badge) => new { Badge = badge, ub.EarnedAtUtc })
+            .FirstOrDefaultAsync(ct);
 
+        if (earnedBadge == null)
+            throw new NotFoundException($"Badge with ID {query.BadgeId} not found for the current user.");
 
         return new BadgeByIdItemDto
         {
-            Id = badge.Id,
-            Name = language == Language.Zh ? badge.NameZh : badge.NameEn,
-            Description = language == Language.Zh ? badge.DescriptionZh : badge.DescriptionEn,
-            IconUrl = badge.IconUrl,
-            Category = badge.Category.ToString(),
+            Id = earnedBadge.Badge.Id,
+            Name = language == Language.Zh ? earnedBadge.Badge.NameZh : earnedBadge.Badge.NameEn,
+            Description = language == Language.Zh ? earnedBadge.Badge.DescriptionZh : earnedBadge.Badge.DescriptionEn,
+            IconUrl = earnedBadge.Badge.IconUrl,
+            Category = earnedBadge.Badge.Category.ToString(),
+            ObtainedAt = earnedBadge.EarnedAtUtc,
         };
     }
 }
@@ -43,4 +51,5 @@ public class BadgeByIdItemDto
     public required string Description { get; set; }
     public required string IconUrl { get; set; }
     public required string Category { get; set; }
+    public required DateTimeOffset ObtainedAt { get; set; }
 }

--- a/blotztask-mobile/src/feature/badge/components/badge-achievement-modal.tsx
+++ b/blotztask-mobile/src/feature/badge/components/badge-achievement-modal.tsx
@@ -71,7 +71,7 @@ export function BadgeAchievementModal({ badge, onDismiss }: BadgeAchievementModa
 
           <Image
             source={{ uri: badge.iconUrl }}
-            style={{ width: 128, height: 128, marginBottom: 20 }}
+            style={{ width: 210, height: 210, marginBottom: 20 }}
             contentFit="contain"
           />
 
@@ -81,11 +81,11 @@ export function BadgeAchievementModal({ badge, onDismiss }: BadgeAchievementModa
             </Text>
           </View>
 
-          <Text className="text-white text-xl font-balooThin text-center w-64">
+          <Text className="text-white text-lg font-balooThin text-center w-64">
             {badge.description}
           </Text>
 
-          <Text className="text-white text-xl font-baloo mt-4">
+          <Text className="text-white text-lg font-baloo mt-4">
             {t("obtainedOn", {
               date: formatLocalizedDate(badge.obtainedAt, "fullMonthDayYear"),
             })}
@@ -102,7 +102,7 @@ export function BadgeAchievementModal({ badge, onDismiss }: BadgeAchievementModa
               }}
               className="min-h-[44px] px-7 py-2.5 rounded-full border-2 border-highlight items-center justify-center"
             >
-              <Text className="text-highlight text-base font-balooBold pt-1">{t("view")}</Text>
+              <Text className="text-highlight text-lg font-balooBold pt-1">{t("view")}</Text>
             </Pressable>
 
             <Pressable
@@ -112,7 +112,7 @@ export function BadgeAchievementModal({ badge, onDismiss }: BadgeAchievementModa
                 isSharingImage ? "opacity-60" : "opacity-100"
               }`}
             >
-              <Text className="text-white text-base font-balooBold pt-1">
+              <Text className="text-white text-lg font-balooBold pt-1">
                 {isSharingImage ? t("sharing") : t("shareReward")}
               </Text>
             </Pressable>

--- a/blotztask-mobile/src/feature/badge/components/badge-share-card.tsx
+++ b/blotztask-mobile/src/feature/badge/components/badge-share-card.tsx
@@ -4,15 +4,13 @@ import { forwardRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Image, Text, View } from "react-native";
 
-interface BadgeShareCardBadge {
-  name: string;
-  description: string;
-  iconUrl: string;
-  obtainedAt?: Date;
-}
-
 interface BadgeShareCardProps {
-  badge: BadgeShareCardBadge;
+  badge: {
+    name: string;
+    description: string;
+    iconUrl: string;
+    obtainedAt: Date;
+  };
 }
 
 function ShareCardBackground() {
@@ -63,13 +61,11 @@ export const BadgeShareCard = forwardRef<View, BadgeShareCardProps>(function Bad
             {badge.description}
           </Text>
 
-          {badge.obtainedAt ? (
-            <Text className="mt-4 scale-110 text-secondary/40 text-sm font-baloo text-center">
-              {t("obtainedOn", {
-                date: formatLocalizedDate(badge.obtainedAt, "fullMonthDayYear"),
-              })}
-            </Text>
-          ) : null}
+          <Text className="mt-4 scale-110 text-secondary/40 text-sm font-baloo text-center">
+            {t("obtainedOn", {
+              date: formatLocalizedDate(badge.obtainedAt, "fullMonthDayYear"),
+            })}
+          </Text>
         </View>
 
         <View

--- a/blotztask-mobile/src/feature/badge/components/badge-share-card.tsx
+++ b/blotztask-mobile/src/feature/badge/components/badge-share-card.tsx
@@ -1,12 +1,18 @@
-import { BadgeNotificationDTO } from "@/feature/badge/models/badge-notification-dto";
 import { ASSETS } from "@/shared/constants/assets";
 import { formatLocalizedDate } from "@/shared/util/localized-date-format";
 import { forwardRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Image, Text, View } from "react-native";
 
+interface BadgeShareCardBadge {
+  name: string;
+  description: string;
+  iconUrl: string;
+  obtainedAt?: Date;
+}
+
 interface BadgeShareCardProps {
-  badge: BadgeNotificationDTO;
+  badge: BadgeShareCardBadge;
 }
 
 function ShareCardBackground() {
@@ -49,9 +55,7 @@ export const BadgeShareCard = forwardRef<View, BadgeShareCardProps>(function Bad
             {t("shareCardHeadline")}
           </Text>
 
-          <Text
-            className="mt-4 w-full text-secondary text-[25px] font-balooBold text-center leading-9"
-          >
+          <Text className="mt-4 w-full text-secondary text-[25px] font-balooBold text-center leading-9">
             {badge.name}
           </Text>
 
@@ -59,11 +63,13 @@ export const BadgeShareCard = forwardRef<View, BadgeShareCardProps>(function Bad
             {badge.description}
           </Text>
 
-          <Text className="mt-4 scale-110 text-secondary/40 text-sm font-baloo text-center">
-            {t("obtainedOn", {
-              date: formatLocalizedDate(badge.obtainedAt, "fullMonthDayYear"),
-            })}
-          </Text>
+          {badge.obtainedAt ? (
+            <Text className="mt-4 scale-110 text-secondary/40 text-sm font-baloo text-center">
+              {t("obtainedOn", {
+                date: formatLocalizedDate(badge.obtainedAt, "fullMonthDayYear"),
+              })}
+            </Text>
+          ) : null}
         </View>
 
         <View

--- a/blotztask-mobile/src/feature/badge/models/badge-by-id-dto.ts
+++ b/blotztask-mobile/src/feature/badge/models/badge-by-id-dto.ts
@@ -3,4 +3,5 @@ export interface BadgeDetailDTO {
   name: string;
   iconUrl: string;
   description: string;
+  obtainedAt: string;
 }

--- a/blotztask-mobile/src/feature/badge/screens/badge-details-screen.tsx
+++ b/blotztask-mobile/src/feature/badge/screens/badge-details-screen.tsx
@@ -9,6 +9,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useBadgeDetailQuery } from "../hooks/useBadgeDetailQuery";
 import { BadgeShareCard } from "@/feature/badge/components/badge-share-card";
 import { useReviewShare } from "@/feature/review/hooks/useReviewShare";
+import { formatLocalizedDate } from "@/shared/util/localized-date-format";
 import { useRef } from "react";
 
 export default function BadgeDetailsScreen() {
@@ -68,6 +69,12 @@ export default function BadgeDetailsScreen() {
               <Text className="text-lg font-balooBold text-gray-500 text-center leading-8 mb-7">
                 {badgeDetail.description}
               </Text>
+
+              <Text className="text-base font-baloo text-gray-400 text-center">
+                {t("obtainedOn", {
+                  date: formatLocalizedDate(new Date(badgeDetail.obtainedAt), "fullMonthDayYear"),
+                })}
+              </Text>
             </View>
 
             <View className="mt-8 flex-row items-center justify-center gap-4">
@@ -97,7 +104,10 @@ export default function BadgeDetailsScreen() {
               Blotz task
             </Text>
           </ScrollView>
-          <BadgeShareCard ref={shareCardRef} badge={badgeDetail} />
+          <BadgeShareCard
+            ref={shareCardRef}
+            badge={{ ...badgeDetail, obtainedAt: new Date(badgeDetail.obtainedAt) }}
+          />
         </>
       )}
     </SafeAreaView>

--- a/blotztask-mobile/src/feature/badge/screens/badge-details-screen.tsx
+++ b/blotztask-mobile/src/feature/badge/screens/badge-details-screen.tsx
@@ -77,7 +77,9 @@ export default function BadgeDetailsScreen() {
               </Text>
             </View>
 
-            <View className="mt-8 flex-row items-center justify-center gap-4">
+            <View className="mt-8 flex-row items-center justify-center">
+              {/* TODO: restore this once equipping a reward is implemented — it was
+                  a console.log placeholder with no behaviour behind it.
               <Pressable
                 className="h-14 min-w-36 rounded-full border border-highlight bg-white/60 px-5 items-center justify-center"
                 onPress={() => console.log("Equip reward", badgeDetail.id)}
@@ -86,6 +88,7 @@ export default function BadgeDetailsScreen() {
                   {t("details.equipReward")}
                 </Text>
               </Pressable>
+              */}
 
               <Pressable
                 className={`h-14 min-w-36 rounded-full bg-highlight px-5 items-center justify-center shadow-lg shadow-lime-300 ${

--- a/blotztask-mobile/src/feature/badge/screens/badge-details-screen.tsx
+++ b/blotztask-mobile/src/feature/badge/screens/badge-details-screen.tsx
@@ -7,9 +7,17 @@ import { useTranslation } from "react-i18next";
 import { Pressable, ScrollView, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useBadgeDetailQuery } from "../hooks/useBadgeDetailQuery";
+import { BadgeShareCard } from "@/feature/badge/components/badge-share-card";
+import { useReviewShare } from "@/feature/review/hooks/useReviewShare";
+import { useRef } from "react";
 
 export default function BadgeDetailsScreen() {
   const { t } = useTranslation("badge");
+  const shareCardRef = useRef<View>(null);
+  const { isSharingImage, shareImage } = useReviewShare({
+    captureTargetRef: shareCardRef,
+  });
+
   const params = useLocalSearchParams<{ badgeId: string }>();
   const badgeId = Number(params.badgeId);
   const { badgeDetail, isBadgeDetailLoading, isBadgeDetailError } = useBadgeDetailQuery(badgeId);
@@ -30,59 +38,67 @@ export default function BadgeDetailsScreen() {
           </View>
         </>
       ) : (
-        <ScrollView
-          className="flex-1"
-          contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 28, paddingBottom: 28 }}
-          showsVerticalScrollIndicator={false}
-        >
-          <View className="pt-4">
-            <ReturnButton />
-          </View>
+        <>
+          <ScrollView
+            className="flex-1"
+            contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 28, paddingBottom: 28 }}
+            showsVerticalScrollIndicator={false}
+          >
+            <View className="pt-4">
+              <ReturnButton />
+            </View>
 
-          <View className="items-center pt-8">
-            <GradientColor className="mb-14">
-              <Text className="text-4xl font-balooExtraBold text-center leading-normal">
-                {t("achievementUnlocked")}
+            <View className="items-center pt-8">
+              <GradientColor className="mb-14">
+                <Text className="text-4xl font-balooExtraBold text-center leading-normal">
+                  {t("achievementUnlocked")}
+                </Text>
+              </GradientColor>
+
+              <Image
+                source={{ uri: badgeDetail.iconUrl }}
+                style={{ width: 235, height: 235, marginBottom: 44 }}
+                contentFit="contain"
+              />
+
+              <Text className="text-3xl font-balooExtraBold text-secondary text-center mb-4">
+                {badgeDetail.name}
               </Text>
-            </GradientColor>
 
-            <Image
-              source={{ uri: badgeDetail.iconUrl }}
-              style={{ width: 235, height: 235, marginBottom: 44 }}
-              contentFit="contain"
-            />
-
-            <Text className="text-3xl font-balooExtraBold text-secondary text-center mb-4">
-              {badgeDetail.name}
-            </Text>
-
-            <Text className="text-lg font-balooBold text-gray-500 text-center leading-8 mb-7">
-              {badgeDetail.description}
-            </Text>
-          </View>
-
-          <View className="mt-8 flex-row items-center justify-center gap-4">
-            <Pressable
-              className="h-14 min-w-36 rounded-full border border-highlight bg-white/60 px-5 items-center justify-center"
-              onPress={() => console.log("Equip reward", badgeDetail.id)}
-            >
-              <Text className="text-lg font-balooBold text-highlight">
-                {t("details.equipReward")}
+              <Text className="text-lg font-balooBold text-gray-500 text-center leading-8 mb-7">
+                {badgeDetail.description}
               </Text>
-            </Pressable>
+            </View>
 
-            <Pressable
-              className="h-14 min-w-36 rounded-full bg-highlight px-5 items-center justify-center shadow-lg shadow-lime-300"
-              onPress={() => console.log("Share reward", badgeDetail.id)}
-            >
-              <Text className="text-lg font-balooBold text-white">{t("shareReward")}</Text>
-            </Pressable>
-          </View>
+            <View className="mt-8 flex-row items-center justify-center gap-4">
+              <Pressable
+                className="h-14 min-w-36 rounded-full border border-highlight bg-white/60 px-5 items-center justify-center"
+                onPress={() => console.log("Equip reward", badgeDetail.id)}
+              >
+                <Text className="text-lg font-balooBold text-highlight">
+                  {t("details.equipReward")}
+                </Text>
+              </Pressable>
 
-          <Text className="mt-auto pt-16 text-center text-lg font-balooBold text-highlight">
-            Blotz task
-          </Text>
-        </ScrollView>
+              <Pressable
+                className={`h-14 min-w-36 rounded-full bg-highlight px-5 items-center justify-center shadow-lg shadow-lime-300 ${
+                  isSharingImage ? "opacity-60" : "opacity-100"
+                }`}
+                onPress={shareImage}
+                disabled={isSharingImage}
+              >
+                <Text className="text-lg font-balooBold text-white">
+                  {isSharingImage ? t("sharing") : t("shareReward")}
+                </Text>
+              </Pressable>
+            </View>
+
+            <Text className="mt-auto pt-16 text-center text-lg font-balooBold text-highlight">
+              Blotz task
+            </Text>
+          </ScrollView>
+          <BadgeShareCard ref={shareCardRef} badge={badgeDetail} />
+        </>
       )}
     </SafeAreaView>
   );

--- a/blotztask-mobile/src/i18n/locales/en/badge.json
+++ b/blotztask-mobile/src/i18n/locales/en/badge.json
@@ -1,5 +1,5 @@
 {
-  "achievementUnlocked": "Achievement unlocked!",
+  "achievementUnlocked": " Achievement unlocked!",
   "shareCardHeadline": "I've unlocked:",
   "obtainedOn": "Obtained on {{date}}",
   "view": "View",

--- a/blotztask-mobile/src/i18n/locales/zh/badge.json
+++ b/blotztask-mobile/src/i18n/locales/zh/badge.json
@@ -1,5 +1,5 @@
 {
-  "achievementUnlocked": "成就解锁！",
+  "achievementUnlocked": " 成就解锁！",
   "shareCardHeadline": "成就解锁！",
   "obtainedOn": "获得于 {{date}}",
   "view": "查看",


### PR DESCRIPTION
## Summary

- Enable system image sharing from the badge detail page.
- Modify badge popout UI.
- Adjust English and Chinese achievement titles for improved visual centering.

## Release note

> Badge detail pages can now share badge images, with improved achievement-title alignment.

**Status:**

- [x] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce