### PR TITLE
Block saving a task whose end time is after its deadline

### DIFF
--- a/blotztask-mobile/src/feature/task-add-edit/components/deadline-section.tsx
+++ b/blotztask-mobile/src/feature/task-add-edit/components/deadline-section.tsx
@@ -1,11 +1,10 @@
 import * as React from "react";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { View, Text, Pressable } from "react-native";
-import Toast from "react-native-toast-message";
 import { Control, UseFormGetValues, useController } from "react-hook-form";
 import { format } from "date-fns";
 import { useTranslation } from "react-i18next";
-import TaskFormField, { hasDeadlineWarning } from "../models/task-form-schema";
+import TaskFormField, { hasDeadlineConflict } from "../models/task-form-schema";
 import Animated from "react-native-reanimated";
 import { MotionAnimations } from "@/shared/constants/animations/motion";
 import { formatLocalizedDate } from "@/shared/util/localized-date-format";
@@ -63,13 +62,20 @@ export const DeadlineSection = ({ control, getValues, isActiveTab }: DeadlineSec
     name: "endDate",
   });
 
-  useEffect(() => {
-    if (!isDeadline) return;
-    const formValues = getValues();
-    if (hasDeadlineWarning({ ...formValues })) {
-      Toast.show({ type: "warning", text1: t("form.invalidDeadlineRange"), visibilityTime: 3000 });
-    }
-  }, [deadlineDate, deadlineTime]);
+  const {
+    field: { value: endTime },
+  } = useController({
+    control,
+    name: "endTime",
+  });
+
+  const isDeadlineInvalid = hasDeadlineConflict({
+    isDeadline,
+    endDate,
+    endTime,
+    deadlineDate,
+    deadlineTime,
+  });
 
   const deadlineDateDisplayText = deadlineDate
     ? formatLocalizedDate(deadlineDate, "abbrevMonthDayYear")
@@ -134,6 +140,14 @@ export const DeadlineSection = ({ control, getValues, isActiveTab }: DeadlineSec
               </Pressable>
             </View>
           </Animated.View>
+
+          {isDeadlineInvalid && (
+            <Animated.View layout={MotionAnimations.layout}>
+              <Text className="text-red-500 text-sm mt-2 font-baloo">
+                {t("form.invalidDeadlineRange")}
+              </Text>
+            </Animated.View>
+          )}
 
           {activeSelector === "deadlineDate" && (
             <Animated.View

--- a/blotztask-mobile/src/feature/task-add-edit/models/task-form-schema.ts
+++ b/blotztask-mobile/src/feature/task-add-edit/models/task-form-schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { combineDateTime } from "../util/combine-date-time";
-import { isBefore, isEqual, startOfDay } from "date-fns";
+import { isAfter, isBefore, isEqual, startOfDay } from "date-fns";
 
 export const recurrenceValues = [
   "never",
@@ -17,27 +17,28 @@ export const recurrenceEndModeValues = ["never", "onDate"] as const;
 const MAX_RECURRING_EVENT_DURATION_DAYS = 31;
 const MAX_RECURRING_EVENT_DURATION_MS = MAX_RECURRING_EVENT_DURATION_DAYS * 24 * 60 * 60 * 1000;
 
-export const taskFormSchema = z
-  .object({
-    title: z
-      .string()
-      .trim()
-      .min(1, "details.mustHaveTitleError")
-      .max(80, "details.titleTooLongError"),
-    description: z.union([z.string().max(1000, "Max 1000 chars"), z.literal("")]).nullable(),
-    startDate: z.date(),
-    startTime: z.date(),
-    endDate: z.date(),
-    endTime: z.date(),
-    labelId: z.number().nullable(),
-    alert: z.number().nullable(),
-    recurrence: z.enum(recurrenceValues),
-    recurrenceEndMode: z.enum(recurrenceEndModeValues),
-    recurrenceEndDate: z.date().nullable(),
-    isDeadline: z.boolean(),
-    deadlineDate: z.date().nullable(),
-    deadlineTime: z.date().nullable(),
-  })
+const taskFormShape = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(1, "details.mustHaveTitleError")
+    .max(80, "details.titleTooLongError"),
+  description: z.union([z.string().max(1000, "Max 1000 chars"), z.literal("")]).nullable(),
+  startDate: z.date(),
+  startTime: z.date(),
+  endDate: z.date(),
+  endTime: z.date(),
+  labelId: z.number().nullable(),
+  alert: z.number().nullable(),
+  recurrence: z.enum(recurrenceValues),
+  recurrenceEndMode: z.enum(recurrenceEndModeValues),
+  recurrenceEndDate: z.date().nullable(),
+  isDeadline: z.boolean(),
+  deadlineDate: z.date().nullable(),
+  deadlineTime: z.date().nullable(),
+});
+
+export const taskFormSchema = taskFormShape
   .refine(
     (data) => {
       const start = combineDateTime(data.startDate, data.startTime);
@@ -94,22 +95,30 @@ export const taskFormSchema = z
       message: "recurrence.endDateBeforeStart",
       path: ["recurrenceEndDate"],
     },
-  );
+  )
+  .refine((data) => !hasDeadlineConflict(data), {
+    message: "form.invalidDeadlineRange",
+    path: ["deadlineTime"],
+  });
 
 export type TaskFormField = z.infer<typeof taskFormSchema>;
 
 export type TimeFormValues = Pick<TaskFormField, "startDate" | "startTime" | "endDate" | "endTime">;
 
-export function hasDeadlineWarning(data: TaskFormField): boolean {
+export type DeadlineConflictValues = Pick<
+  z.infer<typeof taskFormShape>,
+  "isDeadline" | "endDate" | "endTime" | "deadlineDate" | "deadlineTime"
+>;
+
+export function hasDeadlineConflict(data: DeadlineConflictValues): boolean {
   if (!data.isDeadline) return false;
 
-  const endDate = data.endDate;
-  const endTime = data.endTime;
-  const end = combineDateTime(endDate, endTime);
+  const end = combineDateTime(data.endDate, data.endTime);
   const deadline = combineDateTime(data.deadlineDate, data.deadlineTime);
+  // Deadline not picked yet — nothing to compare against.
   if (!end || !deadline) return false;
 
-  return end > deadline;
+  return isAfter(end, deadline);
 }
 
 export default TaskFormField;

--- a/blotztask-mobile/src/i18n/locales/en/tasks.json
+++ b/blotztask-mobile/src/i18n/locales/en/tasks.json
@@ -20,7 +20,7 @@
     "markAsDeadline": "Mark as deadline",
     "dueTime": "Due Time",
     "invalidTimeRange": "Start time cannot be later than end time",
-    "invalidDeadlineRange": "DDL is before the task end time."
+    "invalidDeadlineRange": "Deadline must be at or after the task time"
   },
   "details": {
     "notFound": "Selected Task not found.",

--- a/blotztask-mobile/src/i18n/locales/zh/tasks.json
+++ b/blotztask-mobile/src/i18n/locales/zh/tasks.json
@@ -20,7 +20,7 @@
     "markAsDeadline": "设为截止任务",
     "dueTime": "截止时间",
     "invalidTimeRange": "开始时间不能晚于结束时间",
-    "invalidDeadlineRange": "截止时间早于任务结束时间"
+    "invalidDeadlineRange": "截止时间不能早于任务时间"
   },
   "details": {
     "notFound": "未找到选定的任务。",


### PR DESCRIPTION
## Summary

- `hasDeadlineWarning` → `hasDeadlineConflict`, now wired into the task form's zod schema as a `.refine`, so a task whose end time falls after its deadline can no longer be saved (previously it was only a warning).
- `DeadlineSection` drops the one-shot toast for a persistent inline red error under the deadline row, so the message stays visible while the values are still invalid.
- Reworded the EN/ZH message to state the rule rather than the symptom.

## Release note

> You can no longer save a task whose end time is after its deadline — the deadline field now shows a clear error until you fix it.

**Status:**

- [x] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce
