### PR TITLE
Fix duplicate badge popup and stale achievement list

### DIFF
--- a/blotztask-mobile/src/feature/badge/components/badge-achievement-modal.tsx
+++ b/blotztask-mobile/src/feature/badge/components/badge-achievement-modal.tsx
@@ -106,7 +106,10 @@ export function BadgeAchievementModal({ badge, onDismiss }: BadgeAchievementModa
             </Pressable>
 
             <Pressable
-              onPress={shareImage}
+              onPress={async () => {
+                await shareImage();
+                onDismiss();
+              }}
               disabled={isSharingImage}
               className={`min-h-[44px] px-7 py-2.5 rounded-full border-2 border-transparent bg-highlight items-center justify-center ${
                 isSharingImage ? "opacity-60" : "opacity-100"

--- a/blotztask-mobile/src/feature/settings/screens/settings-screen.tsx
+++ b/blotztask-mobile/src/feature/settings/screens/settings-screen.tsx
@@ -1,8 +1,10 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { View, Text, Pressable, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import MaterialCommunityIcons from "@react-native-vector-icons/material-design-icons/static";
-import { useRouter } from "expo-router";
+import { useFocusEffect, useRouter } from "expo-router";
+import { useQueryClient } from "@tanstack/react-query";
+import { badgeKeys } from "@/shared/constants/query-key-factory";
 import { useUserProfile } from "@/shared/hooks/useUserProfile";
 import { ASSETS } from "@/shared/constants/assets";
 import { FormDivider } from "@/shared/components/form-divider";
@@ -17,6 +19,13 @@ export default function SettingsScreen() {
   const { userProfile } = useUserProfile();
   const { t } = useTranslation("settings");
   const { badges } = useBadgesQuery();
+  const queryClient = useQueryClient();
+
+  useFocusEffect(
+    useCallback(() => {
+      queryClient.invalidateQueries({ queryKey: badgeKeys.all });
+    }, [queryClient]),
+  );
 
   const menuItems: SettingsMenuItem[] = [
     {

--- a/blotztask-mobile/src/shared/hooks/usePushNotificationSetup.ts
+++ b/blotztask-mobile/src/shared/hooks/usePushNotificationSetup.ts
@@ -21,16 +21,17 @@ export function usePushNotificationSetup() {
 
       const earnedAtUtc = typeof data.earnedAtUtc === "string" ? data.earnedAtUtc : undefined;
 
-      setBadgeQueue((prev) => [
-        ...prev,
-        {
-          badgeId: Number(data.badgeId),
-          name: notification.request.content.body ?? "",
-          description: typeof data.description === "string" ? data.description : "",
-          iconUrl: typeof data.iconUrl === "string" ? data.iconUrl : "",
-          obtainedAt: earnedAtUtc ? new Date(earnedAtUtc) : new Date(),
-        },
-      ]);
+      const badge: BadgeNotificationDTO = {
+        badgeId: Number(data.badgeId),
+        name: notification.request.content.body ?? "",
+        description: typeof data.description === "string" ? data.description : "",
+        iconUrl: typeof data.iconUrl === "string" ? data.iconUrl : "",
+        obtainedAt: earnedAtUtc ? new Date(earnedAtUtc) : new Date(),
+      };
+
+      setBadgeQueue((prev) =>
+        prev.some((queued) => queued.badgeId === badge.badgeId) ? prev : [...prev, badge],
+      );
 
       queryClient.invalidateQueries({ queryKey: badgeKeys.all });
     });


### PR DESCRIPTION
## Summary

Two badge bugs from one report:

- **Popup looked stuck.** The same badge could be queued twice: a user can have
  several `UserPushTokens` rows carrying the same Expo token, so Expo delivers the
  push to the device twice. Dismissing the modal revealed an identical copy. Now
  de-duplicated by `badgeId` when queueing.
- **Achievements list was stale.** Badges are awarded server-side after a task
  completes and nothing client-side learned the list had changed — the settings tab
  stays mounted so `refetchOnMount` never fires, and `staleTime` is `Infinity`
  globally. New badges only appeared after an app restart. Now refreshed when the
  settings screen gains focus.

"Share reward" also dismisses the popup once the share sheet closes, matching the
close button.

The duplicate-token root cause is server-side and is tracked separately.

## Release note

> none

**Status:**

- [ ] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [x] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce
