### PR TITLE
Hold Android production release as draft

### DIFF
--- a/blotztask-mobile/eas.json
+++ b/blotztask-mobile/eas.json
@@ -113,7 +113,8 @@
         "ascAppId": "6752492404"
       },
       "android": {
-        "track": "production"
+        "track": "production",
+        "releaseStatus": "draft"
       }
     }
   }


### PR DESCRIPTION
## Summary

`eas submit` was configured to push production Android builds straight to the
`production` track with the default `completed` release status, so a build went
to Google review and rolled out to 100% of users automatically, with no manual
gate.

Setting `releaseStatus: "draft"` makes the AAB upload to Play Console as a draft
release instead. Review only starts once someone publishes it manually, which
lets the Android rollout be sequenced against the iOS release and the production
backend deployment.

The `preview` profile keeps `track: "alpha"` unchanged — internal-only, so it
needs no gate.

## Release note

> _none_

**Status:**

- [ ] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [x] Internal only (refactor / infra / tests / CI / deps) — don't announce
