### PR TITLE
fix: return to the calendar after editing a recurring task

### DIFF
--- a/blotztask-mobile/src/feature/task-add-edit/screens/task-edit-screen.tsx
+++ b/blotztask-mobile/src/feature/task-add-edit/screens/task-edit-screen.tsx
@@ -188,7 +188,7 @@ export default function TaskEditScreen() {
             });
           }
 
-          router.replace({
+          router.dismissTo({
             pathname: "/(protected)/task-details",
             params: {
               mode: TASK_DETAIL_ROUTE_MODE.Persisted,
@@ -242,7 +242,7 @@ export default function TaskEditScreen() {
               updatedTask,
             );
 
-            router.replace({
+            router.dismissTo({
               pathname: "/(protected)/task-details",
               params: {
                 mode: TASK_DETAIL_ROUTE_MODE.Virtual,


### PR DESCRIPTION
## Summary

- Prevent duplicate task detail screens after saving recurring task edits.
- Ensure Back returns to the calendar instead of the previous task detail screen.

## Release note

> Fixed an issue where the Back button could open the wrong screen after editing a recurring task.

**Status:**

- [x] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce