### PR TITLE
fix: prevent recurring icon from overlapping end time

### DIFF
--- a/blotztask-mobile/src/feature/calendar/components/task-card.tsx
+++ b/blotztask-mobile/src/feature/calendar/components/task-card.tsx
@@ -54,7 +54,14 @@ interface TaskCardProps {
   onRowOpen?: (refObject: React.RefObject<SwipeableMethods | null>) => void;
 }
 
-const TaskCard = ({ task, deleteTask, isDeleting, selectedDay, onOpenMode, onRowOpen }: TaskCardProps) => {
+const TaskCard = ({
+  task,
+  deleteTask,
+  isDeleting,
+  selectedDay,
+  onOpenMode,
+  onRowOpen,
+}: TaskCardProps) => {
   const swipeRef = useRef<SwipeableMethods | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
   const progress = useDerivedValue(() => withTiming(isExpanded ? 1 : 0, { duration: 220 }));
@@ -71,12 +78,8 @@ const TaskCard = ({ task, deleteTask, isDeleting, selectedDay, onOpenMode, onRow
   const [pendingFocusTaskId, setPendingFocusTaskId] = useState<number | null>(null);
 
   // Mutations
-  const {
-    toggleTask,
-    deleteRecurringOccurrence,
-    isToggling,
-    isDeletingRecurringOccurrence,
-  } = useTaskMutations();
+  const { toggleTask, deleteRecurringOccurrence, isToggling, isDeletingRecurringOccurrence } =
+    useTaskMutations();
   const {
     completeOccurrence,
     materializeOccurrenceAsync,
@@ -245,7 +248,10 @@ const TaskCard = ({ task, deleteTask, isDeleting, selectedDay, onOpenMode, onRow
 
     setShowSwitchModal(false);
     swipeRef.current?.close();
-    router.push({ pathname: "/(protected)/pomodoro-focus", params: { taskId: pendingFocusTaskId } });
+    router.push({
+      pathname: "/(protected)/pomodoro-focus",
+      params: { taskId: pendingFocusTaskId },
+    });
     setPendingFocusTaskId(null);
   };
 
@@ -342,7 +348,7 @@ const TaskCard = ({ task, deleteTask, isDeleting, selectedDay, onOpenMode, onRow
               <Pressable className="flex-1 " onPress={handleOpenTaskDetails} disabled={isLoading}>
                 <View className="flex-row items-center" style={{ gap: 4 }}>
                   <Text
-                    className={`text-xl font-semibold font-inter ${
+                    className={`flex-1 text-xl font-semibold font-inter ${
                       task.isDone ? "text-neutral-400 line-through" : "text-[#444964]"
                     }`}
                     style={


### PR DESCRIPTION
## Summary

Prevent the recurring icon from overlapping the end time on recurring task cards with long titles.

## Release note

The repeat icon no longer covers the end time on recurring tasks with long titles.
The end time is full readable now.


**Status:**

- [x] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce
