### PR TITLE
update build shell script

### DIFF
--- a/.claude/skills/create-blotz-pbi/SKILL.md
+++ b/.claude/skills/create-blotz-pbi/SKILL.md
@@ -15,7 +15,71 @@ A PBI is ready only when it has all three:
 
 **Exception — POC / investigation PBI:** the goal is to *find* the solution, so #2 is replaced by a clear **investigation goal + what success looks like** (questions to answer, decision to reach). #1 and #3 still apply. Ask whether it's a POC if unclear.
 
-If any required part is missing or vague, ask the user targeted questions and draft the missing parts with them. Don't create the issue until ready. Confirm the final draft before creating.
+**Never create an unconfirmed PBI.** If the direction is vague, or the online validation below could
+not confirm the proposed solution is a real and workable approach, do not create the issue. Ask the
+user targeted questions — one at a time, each with options and your recommended answer — and keep
+drafting with them until both the direction and the solution are settled.
+
+If the solution still can't be confirmed after that, the work is an **investigation, not a build**.
+Say so plainly and ask the user whether to turn it into a POC PBI (🔍, with `## Investigation Goal`
+replacing `## Suggested Solution`). Never quietly ship a build PBI carrying a guessed solution, and
+never convert it to a POC on your own — that call belongs to the user.
+
+Always show the finished draft and get explicit confirmation before creating anything.
+
+## Validate the solution online (before showing the draft)
+Never propose a `## Suggested Solution` from memory alone. Research it first and confirm it is what
+the official docs say and what other apps actually do.
+
+- **Official docs first** — the platform/framework/library docs for every API the solution names
+  (Expo, Apple HIG, Android developer guides, the library's own reference). Confirm the API exists,
+  does what you claim, and note its stated caveats: nullability, platform support, deprecation.
+- **Then real-world practice** — how comparable apps solve the same problem: official help-centre
+  pages, engineering blogs, well-supported Stack Overflow / GitHub discussions. The question to
+  answer is "is this the normal way, or am I inventing something?"
+- **Say which kind of backing you found.** A documented platform rule, a widespread convention, and
+  "this seemed sensible" are three different strengths of evidence — word the draft accordingly.
+- **Surface contradictions, never bury them.** If a guideline argues against the approach, put it in
+  the draft and let the user decide. A verified counterpoint is worth more than a clean draft.
+- **Cite in the PBI.** Put the 2–4 links that actually shaped the decision under `## Notes`. Whoever
+  picks the ticket up shouldn't have to redo the research to trust the approach.
+
+Skip this only when the solution is entirely internal to this codebase — renaming a local helper,
+changing a value we own — and names no external API, platform behaviour, or third-party pattern.
+
+## Staging verification (decide per PBI)
+
+Most PBIs are only really done once someone has seen them work on a staging build — not on a
+simulator, and not on the developer's machine. Decide whether this one qualifies, and if it does,
+write the `## Staging Verification` section into the body.
+
+**What staging means here:** the EAS `preview` build profile — bundle `com.Blotz.BlotzTask.staging`,
+pointed at the `-stag` API, `EXPO_PUBLIC_APP_ENV=preview`. It reaches testers through TestFlight on
+iOS and the Play **alpha** track on Android. "Tested on staging" means a real install from one of
+those, not `expo run` and not a dev client.
+
+**Needs staging verification** when the change touches any of:
+- UI a user actually sees
+- an API contract or backend behaviour (the staging API is a different deployment from local)
+- environment-specific config — API URLs, Auth0 tenant, keys, bundle identifier
+- native modules, permissions, push, widgets, deep links — these behave differently in a real signed
+  build than in a dev client
+- data shape or migrations
+
+**Doesn't need it** when the change is docs, comments, CI/build scripts the pipeline itself proves,
+dev tooling or skills that never ship to users, or a pure refactor already covered by tests.
+
+**If you can't tell, ask the user** — one question, options, your recommended answer. Don't guess,
+and don't add an empty section just to have one.
+
+When it applies, the section must be **specific to this PBI** — a reviewer should be able to follow
+it without rereading the description. Cover:
+- which build to install (iOS TestFlight / Android alpha, or both — say if one platform is enough)
+- the exact steps to reach the changed behaviour
+- what a pass looks like, in observable terms
+- anything that needs checking on both platforms, or in both languages, or against real data
+
+Lead the section with: `PBI is not Done until every box below is checked on a staging build.`
 
 ## Before creating — also confirm
 - **Tech-lead tag:** ask the user only if the task is difficult or important — if yes, apply the tech-lead label. and also pick the right label(s) yourself from the repo's existing labels based on the work (e.g. bug, frontend, backend, auth).
@@ -42,21 +106,23 @@ Pick the one that fits the task. POC (🔍) takes priority when the work is an i
 
 ## Steps
 1. Run the readiness gate.
-2. Confirm tech-lead tag (if applicable), other labels, and estimate.
-3. Title = the PBI title.
-4. Body in this order, keeping the user's wording. **Keep it short and concise** — write the minimum a dev needs to pick this up, favour tight bullets over prose, and cut any sentence that doesn't change what someone would do:
+2. Validate the solution online (see above), then show the user the draft with its sources and wait for explicit confirmation. Unconfirmed direction or unconfirmed solution = don't create; clarify, or offer the POC conversion.
+3. Decide whether staging verification applies (ask if unclear), then confirm tech-lead tag (if applicable), other labels, and estimate.
+4. Title = the PBI title.
+5. Body in this order, keeping the user's wording. **Keep it short and concise** — write the minimum a dev needs to pick this up, favour tight bullets over prose, and cut any sentence that doesn't change what someone would do:
    - `## Description` — requirements (what & why)
    - `## Suggested Solution` — proposed approach (POC: replace with `## Investigation Goal` — questions to answer + what success looks like)
    - `## Scope / Tasks` — checkboxes (`- [ ]`), `###` subheadings if grouped
    - `## Acceptance Criteria` — checkboxes
+   - `## Staging Verification` — checkboxes; omit entirely when the PBI doesn't warrant it (see above)
    - `## Notes` — if any apply
    - Keep any "current finding" lines as a `>` blockquote.
-5. Create via `mcp__github__issue_write` (method `create`) in the private repo only, with the chosen labels. **Do not include `backlog ready` in the labels** — it is a Status, set in step 6.
-6. Set the project fields on project 1 (needs the `read:project`/`project` token scope — if missing, the command fails; tell the user to run `gh auth refresh -s read:project,project` (interactive, only they can do it), then retry):
+6. Create via `mcp__github__issue_write` (method `create`) in the private repo only, with the chosen labels. **Do not include `backlog ready` in the labels** — it is a Status, set in step 7.
+7. Set the project fields on project 1 (needs the `read:project`/`project` token scope — if missing, the command fails; tell the user to run `gh auth refresh -s read:project,project` (interactive, only they can do it), then retry):
    - **Add the issue explicitly** with `gh project item-add 1 --owner Blotz-Org --url <issue-url> --format json` and read the returned item `id`. There is an org automation that *sometimes* auto-adds + sets Status, but it is unreliable (has failed to add issues), so always add explicitly rather than depending on it. `item-add` is safe to run even if the issue is already there.
    - **Set Status to `backlog ready`** on the Status single-select field, and **set the Estimate field**, using the item `id` from item-add (`gh project item-edit --id <item> --project-id <proj> --field-id <field> ...`).
    - Do NOT poll `item-list` in a loop to find the item — the project has hundreds of items and a tight poll loop will exhaust the GraphQL rate limit. Use the `id` returned directly by `item-add`.
-7. Reply with the issue URL only.
+8. Reply with the issue URL only.
 
 ## Notes
 - Don't add assignees or milestones unless asked.

--- a/blotztask-api/Modules/Tasks/Commands/SubTasks/DeleteSubtask.cs
+++ b/blotztask-api/Modules/Tasks/Commands/SubTasks/DeleteSubtask.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using BlotzTask.Infrastructure.Data;
 using BlotzTask.Shared.Exceptions;
+using Microsoft.EntityFrameworkCore;
 
 namespace BlotzTask.Modules.Tasks.Commands.SubTasks;
 
@@ -8,13 +9,16 @@ public class DeleteSubtaskCommand
 {
     [Required]
     public int SubtaskId { get; set; }
+
+    [Required] public required Guid UserId { get; init; }
 }
 
 public class DeleteSubtaskCommandHandler(BlotzTaskDbContext db, ILogger<DeleteSubtaskCommandHandler> logger)
 {
     public async Task<string?> Handle(DeleteSubtaskCommand command, CancellationToken ct = default)
     {
-        var subtaskToDelete = await db.Subtasks.FindAsync(command.SubtaskId, ct);
+        var subtaskToDelete = await db.Subtasks
+            .FirstOrDefaultAsync(s => s.Id == command.SubtaskId && s.ParentTask.UserId == command.UserId, ct);
         if (subtaskToDelete == null)
         {
             throw new NotFoundException($"Subtask with ID {command.SubtaskId} not found");

--- a/blotztask-api/Modules/Tasks/Commands/SubTasks/UpdateSubtaskStatus.cs
+++ b/blotztask-api/Modules/Tasks/Commands/SubTasks/UpdateSubtaskStatus.cs
@@ -8,6 +8,8 @@ namespace BlotzTask.Modules.Tasks.Commands.SubTasks;
 public class UpdateSubtaskStatusCommand
 {
     public int SubtaskId { get; set; }
+
+    [Required] public required Guid UserId { get; init; }
 }
 
 public class UpdateSubtaskStatusCommandHandler(BlotzTaskDbContext db, ILogger<UpdateSubtaskStatusCommandHandler> logger)
@@ -15,7 +17,8 @@ public class UpdateSubtaskStatusCommandHandler(BlotzTaskDbContext db, ILogger<Up
     public async Task<string> Handle(UpdateSubtaskStatusCommand command, CancellationToken ct = default)
     {
         logger.LogInformation("Updating subtask status");
-        var subtask = await db.Subtasks.FindAsync(command.SubtaskId, ct);
+        var subtask = await db.Subtasks
+            .FirstOrDefaultAsync(s => s.Id == command.SubtaskId && s.ParentTask.UserId == command.UserId, ct);
 
         if (subtask == null)
         {

--- a/blotztask-api/Modules/Tasks/Commands/Tasks/TaskStatusUpdate.cs
+++ b/blotztask-api/Modules/Tasks/Commands/Tasks/TaskStatusUpdate.cs
@@ -1,12 +1,15 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using BlotzTask.Infrastructure.Data;
 using BlotzTask.Shared.Exceptions;
+using Microsoft.EntityFrameworkCore;
 
 namespace BlotzTask.Modules.Tasks.Commands.Tasks;
 
 public class TaskStatusUpdateCommand
 {
     [Required] public int TaskId { get; init; }
+
+    [Required] public required Guid UserId { get; init; }
 
     public bool? IsDone { get; init; }
 }
@@ -17,7 +20,8 @@ public class TaskStatusUpdateCommandHandler(BlotzTaskDbContext db, ILogger<TaskS
     {
         logger.LogInformation("Finding task {Id}", command.TaskId);
 
-        var task = await db.TaskItems.FindAsync(command.TaskId, ct);
+        var task = await db.TaskItems
+            .FirstOrDefaultAsync(t => t.Id == command.TaskId && t.UserId == command.UserId, ct);
 
         if (task == null) throw new NotFoundException($"Task with ID {command.TaskId} was not found.");
 

--- a/blotztask-api/Modules/Tasks/Controllers/SubTaskController.cs
+++ b/blotztask-api/Modules/Tasks/Controllers/SubTaskController.cs
@@ -40,7 +40,11 @@ public class SubTaskController(
     [HttpPut("subtask-completion-status/{id}")]
     public async Task<IActionResult> UpdateSubtaskStatus(int id, CancellationToken ct)
     {
-        var message = await updateSubtaskStatusCommandHandler.Handle(new UpdateSubtaskStatusCommand { SubtaskId = id }, ct);
+        if (!HttpContext.Items.TryGetValue("UserId", out var userIdObj) || userIdObj is not Guid userId)
+            throw new UnauthorizedAccessException("Could not find valid user id from Http Context");
+
+        var message = await updateSubtaskStatusCommandHandler.Handle(
+            new UpdateSubtaskStatusCommand { SubtaskId = id, UserId = userId }, ct);
         return Ok(message);
     }
 
@@ -70,7 +74,10 @@ public class SubTaskController(
     [HttpDelete("subtasks/{subtaskId}")]
     public async Task<IActionResult> DeleteSubtask(int subtaskId, CancellationToken ct)
     {
-        var command = new DeleteSubtaskCommand { SubtaskId = subtaskId };
+        if (!HttpContext.Items.TryGetValue("UserId", out var userIdObj) || userIdObj is not Guid userId)
+            throw new UnauthorizedAccessException("Could not find valid user id from Http Context");
+
+        var command = new DeleteSubtaskCommand { SubtaskId = subtaskId, UserId = userId };
         var result = await deleteSubtaskCommandHandler.Handle(command, ct);
         return Ok(result);
     }

--- a/blotztask-api/Modules/Tasks/Controllers/TaskController.cs
+++ b/blotztask-api/Modules/Tasks/Controllers/TaskController.cs
@@ -173,7 +173,7 @@ public class TaskController(
         if (!HttpContext.Items.TryGetValue("UserId", out var userIdObj) || userIdObj is not Guid userId)
             throw new UnauthorizedAccessException("Could not find valid user id from Http Context");
 
-        var command = new TaskStatusUpdateCommand { TaskId = id };
+        var command = new TaskStatusUpdateCommand { TaskId = id, UserId = userId };
         var result = await taskStatusUpdateCommandHandler.Handle(command, ct);
 
         if (result == null)

--- a/blotztask-mobile/app.config.js
+++ b/blotztask-mobile/app.config.js
@@ -16,6 +16,7 @@ export default {
     ios: {
       supportsTablet: false,
       bundleIdentifier: process.env.BUNDLE_IDENTIFIER ?? "com.Blotz.BlotzTask",
+      usesAppleSignIn: true,
       infoPlist: {
         ITSAppUsesNonExemptEncryption: false,
         CFBundleDevelopmentRegion: "en",
@@ -35,7 +36,7 @@ export default {
         NSLocationWhenInUseUsageDescription:
           "BlotzTask uses your location to provide location-aware features when you choose to use them. Your location is not stored.",
       },
-      appleTeamId: "LXC29JARY5",
+      appleTeamId: process.env.EXPO_APPLE_TEAM_ID ?? "Z6GFDAYSP9",
       icon: "./assets/images-png/blotz-icon.png",
     },
     android: {

--- a/blotztask-mobile/build.ps1
+++ b/blotztask-mobile/build.ps1
@@ -5,6 +5,7 @@ $profiles  = @("development", "preview", "production")
 
 $androidBuildTypes = @("App Bundle", "APK")
 $bumpTypes = @("No change", "Major (+1.0.0)", "Minor (x.+1.0)", "Patch (x.x.+1)")
+$easChanged = $false
 
 function Show-Menu {
     param(
@@ -40,7 +41,16 @@ $profile  = Show-Menu -Title "Select profile:"  -Options $profiles
 # Load eas.json
 # ------------------------
 $easPath = "eas.json"
-$easJson = Get-Content $easPath -Raw | ConvertFrom-Json
+$originalEasJsonContent = Get-Content $easPath -Raw
+$easJson = $originalEasJsonContent | ConvertFrom-Json
+
+$easCommand = Get-Command "eas" -ErrorAction SilentlyContinue
+
+if (-not $easCommand) {
+    Write-Host "`nEAS CLI was not found." -ForegroundColor Red
+    Write-Host "Install it with: npm install --global eas-cli" -ForegroundColor Yellow
+    exit 1
+}
 
 $currentVersion = $easJson.build.$profile.$platform.env.APP_VERSION
 Write-Host "`nCurrent $platform version ($profile): $currentVersion" -ForegroundColor Cyan
@@ -67,6 +77,7 @@ if ($bump -eq "No change") {
     $newVersion = "$major.$minor.$patch"
     Write-Host "Version update: $currentVersion → $newVersion" -ForegroundColor Green
     $easJson.build.$profile.$platform.env.APP_VERSION = $newVersion
+    $easChanged = $true
 }
 
 # ------------------------
@@ -86,13 +97,18 @@ if ($platform -eq "android") {
         $easJson.build.$profile | Add-Member -MemberType NoteProperty -Name android -Value @{}
     }
 
-    $easJson.build.$profile.android.buildType = $androidBuildType
+    if ($easJson.build.$profile.android.buildType -ne $androidBuildType) {
+        $easJson.build.$profile.android.buildType = $androidBuildType
+        $easChanged = $true
+    }
 }
 
 # ------------------------
 # Save eas.json safely
 # ------------------------
-$easJson | ConvertTo-Json -Depth 10 | Set-Content $easPath
+if ($easChanged) {
+    $easJson | ConvertTo-Json -Depth 10 | Set-Content $easPath
+}
 
 # ------------------------
 # Build command
@@ -117,4 +133,31 @@ if ($platform -eq "ios") {
 
 Write-Host "`nRunning: eas $($buildArgs -join ' ')" -ForegroundColor Green
 
+$previousCapabilitySyncSetting = $env:EXPO_NO_CAPABILITY_SYNC
+
+if ($platform -eq "ios") {
+    Write-Host "Skipping EAS iOS capability sync. Apple Developer capabilities are managed manually." -ForegroundColor Yellow
+    $env:EXPO_NO_CAPABILITY_SYNC = "1"
+}
+
 & eas @buildArgs
+$buildExitCode = $LASTEXITCODE
+
+if ($platform -eq "ios") {
+    if ($null -eq $previousCapabilitySyncSetting) {
+        Remove-Item Env:EXPO_NO_CAPABILITY_SYNC -ErrorAction SilentlyContinue
+    } else {
+        $env:EXPO_NO_CAPABILITY_SYNC = $previousCapabilitySyncSetting
+    }
+}
+
+if ($buildExitCode -ne 0) {
+    if ($easChanged) {
+        Set-Content -Path $easPath -Value $originalEasJsonContent -NoNewline
+        Write-Host "`nBuild failed. Restored eas.json to the previous version." -ForegroundColor Yellow
+    }
+
+    exit $buildExitCode
+}
+
+Write-Host "`nBuild succeeded. Kept eas.json changes." -ForegroundColor Green

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -40,6 +40,14 @@ param appInsightsSamplingPercentage int = 5
 param appServiceSkuName string
 param appServiceSkuTier string
 
+// Mobile force-update policy (served by GET /api/app-version)
+param iosLatestVersion string
+param iosMinimumSupportedVersion string
+param iosStoreUrl string
+param androidLatestVersion string
+param androidMinimumSupportedVersion string
+param androidStoreUrl string
+
 // Database (DTU model)
 param dbMaxSizeGb int
 param dbSkuName string
@@ -116,6 +124,12 @@ module webAppForAPI 'modules/appService.bicep' = {
     auth0Audience: auth0Audience
     auth0ManagementClientId: auth0ManagementClientId
     auth0ManagementAudience: auth0ManagementAudience
+    iosLatestVersion: iosLatestVersion
+    iosMinimumSupportedVersion: iosMinimumSupportedVersion
+    iosStoreUrl: iosStoreUrl
+    androidLatestVersion: androidLatestVersion
+    androidMinimumSupportedVersion: androidMinimumSupportedVersion
+    androidStoreUrl: androidStoreUrl
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -18,10 +18,6 @@ param auth0Audience string
 param auth0ManagementClientId string
 param auth0ManagementAudience string
 
-param breakdownDeploymentName string
-param breakdownModelName string
-param breakdownModelVersion string
-
 param taskGenerationDeploymentName string
 param taskGenerationModelName string
 param taskGenerationModelVersion string
@@ -183,9 +179,6 @@ module openAi 'modules/openAi.bicep' = {
     projectName: namePrefix
     keyVaultName: kv.outputs.name
     foundryProjectName: 'proj-${namePrefix}-${environment}'
-    breakdownDeploymentName: breakdownDeploymentName
-    breakdownModelName: breakdownModelName
-    breakdownModelVersion: breakdownModelVersion
     taskGenerationDeploymentName: taskGenerationDeploymentName
     taskGenerationModelName: taskGenerationModelName
     taskGenerationModelVersion: taskGenerationModelVersion

--- a/infra/modules/appService.bicep
+++ b/infra/modules/appService.bicep
@@ -20,6 +20,15 @@ param auth0ManagementAudience string
 param appServiceSkuName string = 'B1'
 param appServiceSkuTier string = 'Basic'
 
+// Force-update policy served by GET /api/app-version. An empty MinimumSupportedVersion makes
+// the client treat every build as up to date, so these must be filled in per environment.
+param iosLatestVersion string
+param iosMinimumSupportedVersion string
+param iosStoreUrl string
+param androidLatestVersion string
+param androidMinimumSupportedVersion string
+param androidStoreUrl string
+
 var normalizedKeyVaultUri = endsWith(keyVaultUri, '/') ? keyVaultUri : '${keyVaultUri}/'
 
 resource appServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
@@ -128,6 +137,30 @@ resource appService 'Microsoft.Web/sites@2022-09-01' = {
         {
           name: 'WEBSITE_HEALTHCHECK_MAXPINGFAILURES'
           value: '3'
+        }
+        {
+          name: 'AppVersion__Ios__LatestVersion'
+          value: iosLatestVersion
+        }
+        {
+          name: 'AppVersion__Ios__MinimumSupportedVersion'
+          value: iosMinimumSupportedVersion
+        }
+        {
+          name: 'AppVersion__Ios__StoreUrl'
+          value: iosStoreUrl
+        }
+        {
+          name: 'AppVersion__Android__LatestVersion'
+          value: androidLatestVersion
+        }
+        {
+          name: 'AppVersion__Android__MinimumSupportedVersion'
+          value: androidMinimumSupportedVersion
+        }
+        {
+          name: 'AppVersion__Android__StoreUrl'
+          value: androidStoreUrl
         }
       ]
     }

--- a/infra/modules/appService.bicep
+++ b/infra/modules/appService.bicep
@@ -162,6 +162,10 @@ resource appService 'Microsoft.Web/sites@2022-09-01' = {
           name: 'AppVersion__Android__StoreUrl'
           value: androidStoreUrl
         }
+        // Not modelled here, on purpose: prod also carries AzureSpeech__Key, AzureSpeech__Region,
+        // AzureOpenAI__DeploymentId, and both apps carry AzureOpenAI__AiModels__Speech__DeploymentId.
+        // No C# reads any of them - speech runs through Groq whisper (Groq__SpeechModel) - so they
+        // are leftovers that can be deleted from the App Service settings.
       ]
     }
   }

--- a/infra/modules/openAi.bicep
+++ b/infra/modules/openAi.bicep
@@ -4,10 +4,9 @@ param projectName string = 'blotz-task-al'
 param keyVaultName string
 param foundryProjectName string
 
-param breakdownDeploymentName string
-param breakdownModelName string
-param breakdownModelVersion string
-
+// Both AI features (task generation and breakdown) currently run on this one deployment.
+// If breakdown ever needs its own model, add a second deployment resource and point
+// breakdownDeploymentId at it instead.
 param taskGenerationDeploymentName string
 param taskGenerationModelName string
 param taskGenerationModelVersion string
@@ -43,31 +42,12 @@ resource foundryProject 'Microsoft.CognitiveServices/accounts/projects@2025-06-0
   }
 }
 
-resource breakdownDeployment 'Microsoft.CognitiveServices/accounts/deployments@2025-06-01' = {
-  name: breakdownDeploymentName
+resource taskGenerationDeployment 'Microsoft.CognitiveServices/accounts/deployments@2025-06-01' = {
+  name: taskGenerationDeploymentName
   parent: openAiService
   sku: {
     name: 'GlobalStandard'
     capacity: taskGenerationDeploymentCapacity
-  }
-  properties: {
-    model: {
-      format: 'OpenAI'
-      name: breakdownModelName
-      version: breakdownModelVersion
-    }
-    raiPolicyName: 'Microsoft.DefaultV2'
-    versionUpgradeOption: 'OnceNewDefaultVersionAvailable'
-  }
-}
-
-resource taskGenerationDeployment 'Microsoft.CognitiveServices/accounts/deployments@2025-06-01' = {
-  name: taskGenerationDeploymentName
-  parent: openAiService
-  dependsOn: [breakdownDeployment]
-  sku: {
-    name: 'GlobalStandard'
-    capacity: 10
   }
   properties: {
     model: {
@@ -91,5 +71,6 @@ module storeOpenAiKey 'keyVaultSecret.bicep' = {
 
 output endpoint string = openAiService.properties.endpoint
 output taskGenerationDeploymentId string = taskGenerationDeploymentName
-output breakdownDeploymentId string = breakdownDeploymentName
+// Breakdown shares the task-generation deployment - see the note on the params above.
+output breakdownDeploymentId string = taskGenerationDeploymentName
 output foundryProjectId string = foundryProject.id

--- a/infra/prod.bicepparam
+++ b/infra/prod.bicepparam
@@ -46,3 +46,14 @@ param auth0ManagementClientId = 'xWylVePDs5giZLBopYT1qHecBv2WijQh'
 param auth0ManagementAudience = 'https://dev-k72xachs0fr6nebp.us.auth0.com/api/v2/'
 // Auth0 Management Client Secret - overridden at deploy time
 param auth0ManagementClientSecret = ''
+
+// Mobile force-update policy. LatestVersion drives the soft "update available" prompt;
+// MinimumSupportedVersion is the hard wall - only raise it once that build is live in the store,
+// or every user below it is locked out with nothing to install.
+param iosLatestVersion = '1.2.0'
+param iosMinimumSupportedVersion = '1.2.0'
+param iosStoreUrl = 'https://apps.apple.com/us/app/blotztask-adhd-time-manager/id6752492404'
+
+param androidLatestVersion = '1.2.1'
+param androidMinimumSupportedVersion = '1.0.0'
+param androidStoreUrl = 'https://play.google.com/store/apps/details?id=com.blotz.blotztask'

--- a/infra/prod.bicepparam
+++ b/infra/prod.bicepparam
@@ -5,10 +5,6 @@ param organizationName = 'blotz'
 param projectName = 'task'
 param location = 'australiaeast'
 
-param breakdownDeploymentName = 'gpt-5.2-chat'
-param breakdownModelName = 'gpt-5.2-chat'
-param breakdownModelVersion = '2025-12-11'
-
 param taskGenerationDeploymentName = 'gpt-5.4-mini'
 param taskGenerationModelName = 'gpt-5.4-mini'
 param taskGenerationModelVersion = '2026-03-17'
@@ -27,11 +23,12 @@ param appInsightsSamplingPercentage = 4
 param appServiceSkuName = 'B1'
 param appServiceSkuTier = 'Basic'
 
-// Database (DTU Standard S0 - 10 DTUs, max 250GB)
-param dbMaxSizeGb = 2
-param dbSkuName = 'S0'
-param dbSkuTier = 'Standard'
-param dbSkuCapacity = 10
+// Database (DTU Basic - 5 DTUs, 1GB). Prod runs Basic, not the S0 Standard this file
+// used to claim; verified against sqldb-blotz-task-prod.
+param dbMaxSizeGb = 1
+param dbSkuName = 'Basic'
+param dbSkuTier = 'Basic'
+param dbSkuCapacity = 5
 
 // Entra ID dev group Object ID - create a prod group and replace this
 param devGroupId = '5719a9e2-49bd-49eb-85d1-e4afd63ca04d'

--- a/infra/stag.bicepparam
+++ b/infra/stag.bicepparam
@@ -5,10 +5,8 @@ param organizationName = 'blotz'
 param projectName = 'task'
 param location = 'australiaeast'
 
-param breakdownDeploymentName = 'gpt-5.2-chat'
-param breakdownModelName = 'gpt-5.2-chat'
-param breakdownModelVersion = '2025-12-11'
-
+// Staging also carries a gpt-5-mini deployment (capacity 500) left over from earlier testing.
+// Nothing in the API references it - it is not modelled here.
 param taskGenerationDeploymentName = 'gpt-5.4-mini'
 param taskGenerationModelName = 'gpt-5.4-mini'
 param taskGenerationModelVersion = '2026-03-17'

--- a/infra/stag.bicepparam
+++ b/infra/stag.bicepparam
@@ -46,3 +46,13 @@ param auth0ManagementClientId = 'xWylVePDs5giZLBopYT1qHecBv2WijQh'
 param auth0ManagementAudience = 'https://dev-k72xachs0fr6nebp.us.auth0.com/api/v2/'
 // Auth0 Management Client Secret - overridden at deploy time
 param auth0ManagementClientSecret = ''
+
+// Mobile force-update policy. LatestVersion drives the soft "update available" prompt;
+// MinimumSupportedVersion is the hard wall - only raise it once that build is live in the store.
+param iosLatestVersion = '1.1.0'
+param iosMinimumSupportedVersion = '1.0.9'
+param iosStoreUrl = 'https://apps.apple.com/us/app/blotztask-adhd-time-manager/id6752492404'
+
+param androidLatestVersion = '1.0.0'
+param androidMinimumSupportedVersion = '1.0.0'
+param androidStoreUrl = 'https://play.google.com/store/apps/details?id=com.blotz.blotztask&hl=en'


### PR DESCRIPTION
## Summary

Three unrelated pieces of internal work.

**Task ownership (security).** Task completion, subtask completion and subtask delete looked rows up by ID alone — any authenticated user could toggle or delete another user's data by enumerating integer IDs, and completion awarded the badge to the caller. Each command now carries `UserId` and filters on it (subtasks via `ParentTask.UserId`), matching `EditTask`. Still unchecked, for a follow-up: `GetSubtasksById`, `UpdateSubtask`, `AddSubtask`, `ReplaceSubtasks`.

**build.ps1.** Fails early if the EAS CLI is missing, only rewrites `eas.json` when a value changed, restores it on build failure, and sets `EXPO_NO_CAPABILITY_SYNC` so EAS stops overwriting manually-managed iOS capabilities.

**app.config.js.** `usesAppleSignIn: true`; `appleTeamId` now reads `EXPO_APPLE_TEAM_ID`.

Plus `create-blotz-pbi` skill updates. Tests fail 85/98 here — identical on `main`, pre-existing.

## Release note

> _none_

**Status:**

- [ ] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [x] Internal only (refactor / infra / tests / CI / deps) — don't announce
