### PR TITLE
Change release note workflow as scheduled

### DIFF
--- a/.github/workflows/preview-next-release.yml
+++ b/.github/workflows/preview-next-release.yml
@@ -7,22 +7,11 @@ name: Preview Next Release
 # section each PR author fills in (see .github/pull_request_template.md) — and
 # uses Azure OpenAI to draft friendly "What's New" copy: it omits work marked
 # internal or hidden-in-production, and tags beta features as "(beta)".
-#
-# Refreshes when a release is published and on demand.
-# Uses the Azure OpenAI v1 API (requires the AZURE_OPENAI_ENDPOINT — the
-# "https://<resource>.openai.azure.com/openai/v1" base shown in Foundry, no
-# trailing slash — plus AZURE_OPENAI_API_KEY and AZURE_OPENAI_DEPLOYMENT repo
-# secrets; GitHub Models was retired).
 
 on:
   release:
     types: [published]
   workflow_dispatch:
-    inputs:
-      deployment:
-        description: "Azure OpenAI deployment name (defaults to the AZURE_OPENAI_DEPLOYMENT secret)"
-        required: false
-        default: ""
 
 permissions:
   contents: write
@@ -67,8 +56,10 @@ jobs:
                     | map(select(length > 0))
                     | if length == 0 then "" else "\n" + join("\n") end )
             ' > prs.txt
-          COUNT=$(grep -c '^#' prs.txt)
+          # grep exits 1 when nothing matches, which would kill the step under `bash -e`.
+          COUNT=$(grep -c '^#' prs.txt || true)
           echo "prev_tag=${PREV_TAG:-none}" >> "$GITHUB_OUTPUT"
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           echo "Collected $COUNT PRs since ${PREV_TAG:-start} ($(wc -c < prs.txt) bytes)."
           # The 100 above is a fetch cap, not a filter: gh returns the newest 100 merged
           # PRs and jq then narrows by date. If a cycle ever exceeds it, older PRs are
@@ -78,16 +69,16 @@ jobs:
           fi
 
       - name: Summarize with Azure OpenAI
+        if: steps.collect.outputs.count != '0'
         env:
           AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
           AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
           AZURE_OPENAI_DEPLOYMENT: ${{ secrets.AZURE_OPENAI_DEPLOYMENT }}
         run: |
-          DEPLOYMENT="${{ inputs.deployment }}"; [ -z "$DEPLOYMENT" ] && DEPLOYMENT="$AZURE_OPENAI_DEPLOYMENT"
           SYSTEM='You write user-facing release notes ("What'\''s New") for BlotzTask, an ADHD-friendly mobile task manager. You receive the pull requests merged since the last release. Each PR may include a "Release note" line (a user-facing sentence) and a "Status" checklist. RULES: (1) If a PR is marked "Internal only" or "Hidden in production", OMIT it entirely. (2) If marked "Beta", place it under the "Beta features" section. (3) Prefer the PR'\''s "Release note" sentence for wording. (4) For PRs with no Release note section, judge conservatively from the title: include ONLY if it is clearly a user-visible feature or improvement, and when unsure, omit it. Never invent a feature or assume something is live in production. (5) Organize the notes under up to three markdown sections, in this order: "### ✨ New features", "### 🐛 Bug fixes", "### 🧪 Beta features". Place each item under the section that fits best (anything marked Beta goes under "Beta features"), as a short friendly bullet starting with a relevant emoji. OMIT any section that would be empty. Output only these sections, no preamble.'
 
-          jq -n --arg deployment "$DEPLOYMENT" --arg sys "$SYSTEM" --rawfile prs prs.txt \
-            '{model:$deployment, temperature:0.3,
+          jq -n --arg deployment "$AZURE_OPENAI_DEPLOYMENT" --arg sys "$SYSTEM" --rawfile prs prs.txt \
+            '{model:$deployment,
               messages:[{role:"system",content:$sys},
                         {role:"user",content:("PRs merged since the last release:\n\n"+$prs)}]}' > body.json
 
@@ -97,19 +88,23 @@ jobs:
           if [ "$HTTP" != "200" ]; then
             echo "Azure OpenAI request failed (HTTP $HTTP):"; cat resp.json; exit 1
           fi
-          jq -r '.choices[0].message.content' resp.json > notes.md
+          # A content-filtered response is HTTP 200 with a null content; don't write "null" into the release.
+          jq -r '.choices[0].message.content // empty' resp.json > notes.md
+          if [ ! -s notes.md ]; then
+            echo "Azure OpenAI returned no content:"; cat resp.json; exit 1
+          fi
 
       - name: Translate the summary into Simplified Chinese
+        if: steps.collect.outputs.count != '0'
         env:
           AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
           AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
           AZURE_OPENAI_DEPLOYMENT: ${{ secrets.AZURE_OPENAI_DEPLOYMENT }}
         run: |
-          DEPLOYMENT="${{ inputs.deployment }}"; [ -z "$DEPLOYMENT" ] && DEPLOYMENT="$AZURE_OPENAI_DEPLOYMENT"
           SYSTEM='你是 BlotzTask（一款帮助 ADHD 用户的手机待办 app）的中文本地化专家。你会收到一段面向用户的英文更新说明（markdown 格式），把它翻译成简体中文。【语气】像 app 里的产品文案，轻松、口语、简洁；统一用「你」称呼用户，绝不用「您」；多用短句和祈使句，避免翻译腔，不要出现「进行」「该」「其」「对……进行」这类书面赘词，读起来要像中国团队自己写的。【术语表，必须统一】task=任务；draft=草稿；note=笔记；Persistent Note=持久笔记；badge=徽章；Pomodoro=番茄钟；subtask=子任务；recurring task=重复任务；swipe to delete=滑动删除；time picker=时间选择器；hold-to-talk=按住说话；Apple Calendar=Apple 日历；card=卡片；AI usage limit=AI 使用额度；availability view=空闲时间视图；daylight saving=夏令时。【格式】(1) 完整保留 markdown 结构和每一个 emoji，位置不变；(2) 章节标题也要翻译：「### ✨ New features」→「### ✨ 新功能」，「### 🐛 Bug fixes」→「### 🐛 问题修复」，「### 🧪 Beta features」→「### 🧪 测试版功能」；(3) 「(beta)」标记译成「（测试版）」；(4) 逐条一一对应翻译，不增加、不删减、不合并、不调整顺序；(5) 只输出翻译后的 markdown，不要任何前言或解释。'
 
-          jq -n --arg deployment "$DEPLOYMENT" --arg sys "$SYSTEM" --rawfile notes notes.md \
-            '{model:$deployment, temperature:0.3,
+          jq -n --arg deployment "$AZURE_OPENAI_DEPLOYMENT" --arg sys "$SYSTEM" --rawfile notes notes.md \
+            '{model:$deployment,
               messages:[{role:"system",content:$sys},
                         {role:"user",content:("把下面这段更新说明翻译成简体中文：\n\n"+$notes)}]}' > body.zh.json
 
@@ -119,9 +114,13 @@ jobs:
           if [ "$HTTP" != "200" ]; then
             echo "Azure OpenAI translation request failed (HTTP $HTTP):"; cat resp.zh.json; exit 1
           fi
-          jq -r '.choices[0].message.content' resp.zh.json > notes.zh.md
+          jq -r '.choices[0].message.content // empty' resp.zh.json > notes.zh.md
+          if [ ! -s notes.zh.md ]; then
+            echo "Azure OpenAI translation returned no content:"; cat resp.zh.json; exit 1
+          fi
 
       - name: Upsert the draft with the AI summary
+        if: steps.collect.outputs.count != '0'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/preview-next-release.yml
+++ b/.github/workflows/preview-next-release.yml
@@ -8,15 +8,13 @@ name: Preview Next Release
 # uses Azure OpenAI to draft friendly "What's New" copy: it omits work marked
 # internal or hidden-in-production, and tags beta features as "(beta)".
 #
-# Refreshes on every merge to main, when a release is published, and on demand.
+# Refreshes when a release is published and on demand.
 # Uses the Azure OpenAI v1 API (requires the AZURE_OPENAI_ENDPOINT — the
 # "https://<resource>.openai.azure.com/openai/v1" base shown in Foundry, no
 # trailing slash — plus AZURE_OPENAI_API_KEY and AZURE_OPENAI_DEPLOYMENT repo
 # secrets; GitHub Models was retired).
 
 on:
-  push:
-    branches: [main]
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? -->

## Release note

<!--
Write ONE sentence a normal user would understand — or "none".
Then tick exactly ONE status below. This feeds the user-facing release notes
("What's New"), so please be accurate about whether users actually see this.
-->

> _your one-line user-facing note here, or "none"_

**Status:**

- [ ] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [x] Internal only (refactor / infra / tests / CI / deps) — don't announce
