### PR TITLE
support separate zh/en screenshots per card for future whatnew

### DIFF
--- a/.claude/skills/generate-whatsnew/SKILL.md
+++ b/.claude/skills/generate-whatsnew/SKILL.md
@@ -45,20 +45,20 @@ Screenshots must be **real** — never sourced from the web, never mocked up. If
 
 #### 1. Produce the screenshot brief
 
-After settling ②, write a clear brief listing every screenshot needed. For each one, state:
+After settling ②, write a clear brief listing every screenshot needed. Each screenshot card needs **two** screenshots — one with the app in Chinese, one with the app in English (switch language in Settings) — never the same image reused for both. For each card, state:
 
 - **Screen / state**: exactly where in the app to navigate (e.g. "Badges tab → tap any badge → Badge Detail sheet")
 - **What to show**: what should be visible in the frame (e.g. "the badge image, name, description, and progress bar — ideally with the badge already unlocked")
-- **Filename**: the target filename in `blotztask-mobile/assets/images-png/whatsnew/`, e.g. `whatsnew-badge-detail.png`
+- **Filenames**: the target filenames in `blotztask-mobile/assets/images-png/whatsnew/`, one per language, e.g. `whatsnew-badge-detail-zh.png` and `whatsnew-badge-detail-en.png`
 
-Present this list to the developer and ask them to take the screenshots and send them back in the conversation. Screenshots come from a real device or simulator running a build that already has the unreleased features — the developer chooses which.
+Present this list to the developer and ask them to take both language versions of each screenshot and send them back in the conversation. Screenshots come from a real device or simulator running a build that already has the unreleased features — the developer chooses which.
 
 #### 2. Receive and save the screenshots
 
 The developer sends the screenshots directly in the conversation. When they arrive:
 
 1. **Delete all existing files** in `blotztask-mobile/assets/images-png/whatsnew/` — each release replaces the previous one entirely. Old screenshots are dead weight: users have already seen that What's New screen and will never see it again, and each build is self-contained so older installs are unaffected.
-2. Note which filename each image maps to from the brief.
+2. Note which `-zh` / `-en` filename each image maps to from the brief.
 3. Save each one to `blotztask-mobile/assets/images-png/whatsnew/<filename>.png` — this is the final location the app code will reference, so no second move is needed.
 4. If an image is very wide (original device resolution), scale it to ~480 px wide: `sips --resampleWidth 480 <file>`.
 
@@ -80,7 +80,7 @@ Give the artifact to the reviewer (the developer / Ben). Revise whatever they do
 
 Once approved, **Claude edits the code but does not open the PR** (Ben's decision, 2026-07-19).
 
-1. Create a branch and fill the copy and images into the content slot the developer left.
+1. Create a branch and fill the copy into the content slot the developer left. For each screenshot card in `cards.ts`, set both `imageZh` and `imageEn` to the matching `-zh` / `-en` file from ③.
 2. Hand it over: tell them the branch name and which files changed.
 3. **The developer opens the app locally, swipes through the onboarding, confirms it renders correctly — and opens the PR themselves.**
 

--- a/blotztask-mobile/src/feature/whats-new/content/cards.ts
+++ b/blotztask-mobile/src/feature/whats-new/content/cards.ts
@@ -7,7 +7,9 @@ export const WHATS_NEW_VERSION = "2026-07";
 type ScreenshotCard = {
   type: "screenshot";
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  image: any;
+  imageZh: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  imageEn: any;
   titleKey: string;
   bodyKey: string;
 };
@@ -37,25 +39,29 @@ export const WHATS_NEW_CARDS: WhatsNewCard[] = [
   },
   {
     type: "screenshot",
-    image: require("../../../../assets/images-png/whatsnew/whatsnew-badge-detail.png"),
+    imageZh: require("../../../../assets/images-png/whatsnew/whatsnew-badge-detail.png"),
+    imageEn: require("../../../../assets/images-png/whatsnew/whatsnew-badge-detail.png"),
     titleKey: "badge-detail.title",
     bodyKey: "badge-detail.body",
   },
   {
     type: "screenshot",
-    image: require("../../../../assets/images-png/whatsnew/whatsnew-persistent-note.png"),
+    imageZh: require("../../../../assets/images-png/whatsnew/whatsnew-persistent-note.png"),
+    imageEn: require("../../../../assets/images-png/whatsnew/whatsnew-persistent-note.png"),
     titleKey: "persistent-note.title",
     bodyKey: "persistent-note.body",
   },
   {
     type: "screenshot",
-    image: require("../../../../assets/images-png/whatsnew/whatsnew-widget.png"),
+    imageZh: require("../../../../assets/images-png/whatsnew/whatsnew-widget.png"),
+    imageEn: require("../../../../assets/images-png/whatsnew/whatsnew-widget.png"),
     titleKey: "widget.title",
     bodyKey: "widget.body",
   },
   {
     type: "screenshot",
-    image: require("../../../../assets/images-png/whatsnew/whatsnew-firework.png"),
+    imageZh: require("../../../../assets/images-png/whatsnew/whatsnew-firework.png"),
+    imageEn: require("../../../../assets/images-png/whatsnew/whatsnew-firework.png"),
     titleKey: "firework.title",
     bodyKey: "firework.body",
   },

--- a/blotztask-mobile/src/feature/whats-new/screens/whats-new-screen.tsx
+++ b/blotztask-mobile/src/feature/whats-new/screens/whats-new-screen.tsx
@@ -110,11 +110,12 @@ function IntroCard({ card }: { card: Extract<WhatsNewCard, { type: "intro" }> })
 }
 
 function ScreenshotCard({ card }: { card: Extract<WhatsNewCard, { type: "screenshot" }> }) {
-  const { t } = useTranslation("whatsNew");
+  const { t, i18n } = useTranslation("whatsNew");
+  const image = i18n.language === "en" ? card.imageEn : card.imageZh;
   return (
     <View className="flex-1 items-center px-6 pt-4 pb-2">
       <View className="w-full flex-1 rounded-3xl overflow-hidden mb-6">
-        <Image source={card.image} style={{ flex: 1, width: "100%" }} contentFit="contain" />
+        <Image source={image} style={{ flex: 1, width: "100%" }} contentFit="contain" />
       </View>
       <Text className="text-2xl font-balooBold text-black text-center mb-2">
         {t(card.titleKey)}


### PR DESCRIPTION
## Summary

Fixes the `generate-whatsnew` skill and the What's New content model so future cards can show separate Chinese and English screenshots, instead of always showing the Chinese one to English users. `ScreenshotCard` in `cards.ts` now requires both `imageZh` and `imageEn`, and the render logic picks the right one by `i18n.language` with no fallback. The 4 existing cards from this release temporarily point both fields at the same Chinese screenshot, since no English shots were taken for it — behavior for this release is unchanged.

## Release note

> none

**Status:**

- [ ] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [x] Internal only (refactor / infra / tests / CI / deps) — don't announce