### PR TITLE
feat: track AI sheet opens and classify mic permission outcomes

### DIFF
--- a/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
@@ -20,7 +20,7 @@ import MaterialCommunityIcons from "@react-native-vector-icons/material-design-i
 import LottieView from "lottie-react-native";
 import { router } from "expo-router";
 import * as Haptics from "expo-haptics";
-import { requestRecordingPermissionsAsync } from "expo-audio";
+import { getRecordingPermissionsAsync, requestRecordingPermissionsAsync } from "expo-audio";
 import { useTranslation } from "react-i18next";
 import { LOTTIE_ANIMATIONS } from "@/shared/constants/assets";
 import { AiResultList } from "../component/ai-result-list";
@@ -82,19 +82,59 @@ export default function AiTaskSheetScreen() {
     useTaskMutations();
   const { createNoteAsync, isNoteCreating } = useNotesMutation();
 
-  // Request mic permission on mount; navigate back if denied
+  // Resolve mic permission on mount; navigate back if unusable.
+  // Get-then-request (as in shared/services/notifications.ts) separates denied from blocked.
   useEffect(() => {
-    requestRecordingPermissionsAsync().then(({ granted }) => {
-      if (!granted) {
-        console.warn("[Mic] Permission not granted");
-        analytics.trackAiTaskGenerationFailed({
-          inputMode: "voice",
-          stage: "permission",
-          errorCode: "PermissionDenied",
-        });
-        router.back();
+    analytics.trackAiTaskSheetOpened();
+
+    // Dismissing mid-await would otherwise pop a screen the user has already left.
+    let isActive = true;
+
+    const exitOnUnusableMic = () => {
+      console.warn("[Mic] Permission not granted");
+      analytics.trackAiTaskGenerationFailed({
+        inputMode: "voice",
+        stage: "permission",
+        errorCode: "PermissionDenied",
+      });
+      if (isActive) router.back();
+    };
+
+    const resolveMicPermission = async () => {
+      const current = await getRecordingPermissionsAsync();
+
+      if (current.granted) {
+        analytics.trackMicPermissionResolved({ outcome: "already_granted" });
+        return;
       }
+
+      // No prompt will be shown, so a request here is indistinguishable from a real rejection.
+      if (!current.canAskAgain) {
+        analytics.trackMicPermissionResolved({ outcome: "blocked" });
+        exitOnUnusableMic();
+        return;
+      }
+
+      const requested = await requestRecordingPermissionsAsync();
+      analytics.trackMicPermissionResolved({
+        outcome: requested.granted ? "granted" : "denied",
+      });
+
+      if (!requested.granted) exitOnUnusableMic();
+    };
+
+    void resolveMicPermission().catch((error: unknown) => {
+      // Previously an unhandled rejection. The sheet still stays open; only the silence is fixed.
+      console.warn("[Mic] Permission check failed.", error);
+      analytics.trackMicPermissionResolved({
+        outcome: "error",
+        errorCode: "PermissionCheckFailed",
+      });
     });
+
+    return () => {
+      isActive = false;
+    };
   }, []);
 
   // --- Derived data ---

--- a/blotztask-mobile/src/shared/constants/posthog-events.ts
+++ b/blotztask-mobile/src/shared/constants/posthog-events.ts
@@ -7,6 +7,8 @@ export const EVENTS = {
   LOGIN_FAILED: "login_failed",
   AI_TASK_GENERATION_SESSION: "ai_task_generation_session",
   AI_TASK_GENERATION_FAILED: "ai_task_generation_failed",
+  AI_TASK_SHEET_OPENED: "ai_task_sheet_opened",
+  MIC_PERMISSION_RESOLVED: "mic_permission_resolved",
   ACTIVE_USER_5S: "active_user_5s",
   BREAKDOWN_TASK: "breakdown_task",
   SCREEN_VIEWED: "screen_viewed",
@@ -62,6 +64,17 @@ export type AiTaskFailureStage =
   | "send"
   | "transcription"
   | "generation";
+
+/**
+ * Microphone permission outcome for the AI voice flow. `already_granted` involves no prompt, so
+ * it is not a grant decision. `blocked` (`canAskAgain` false) can only be fixed in Settings.
+ */
+export type MicPermissionOutcome =
+  | "already_granted"
+  | "granted"
+  | "denied"
+  | "blocked"
+  | "error";
 
 export type AiTaskGenerationTurn = {
   turn_index: number;

--- a/blotztask-mobile/src/shared/services/analytics.ts
+++ b/blotztask-mobile/src/shared/services/analytics.ts
@@ -8,6 +8,7 @@ import {
   type AiTaskGenerationTurn,
   type AiTaskInputMode,
   type AiTaskOutcome,
+  type MicPermissionOutcome,
   type LoginConnection,
   type LoginErrorCode,
   type LoginFailureReason,
@@ -153,6 +154,26 @@ export const analytics = {
     };
     if (params.durationMs !== undefined) properties.duration_ms = params.durationMs;
     posthog.capture(EVENTS.AI_TASK_GENERATION_FAILED, properties);
+  },
+
+  /**
+   * Fires when the AI sheet mounts. The denominator for AI attempts: the session event fires
+   * only on exit and drops itself when no turn was recorded, so opens were previously invisible.
+   */
+  trackAiTaskSheetOpened() {
+    posthog.capture(EVENTS.AI_TASK_SHEET_OPENED);
+  },
+
+  /**
+   * Fires once per AI sheet open, when the mic permission question has an answer.
+   * `outcome` is classified from the state read *before* asking; that is the only way to
+   * separate a fresh rejection (`denied`) from one the OS will not re-prompt for (`blocked`).
+   */
+  trackMicPermissionResolved(params: { outcome: MicPermissionOutcome; errorCode?: string }) {
+    posthog.capture(EVENTS.MIC_PERMISSION_RESOLVED, {
+      outcome: params.outcome,
+      ...(params.errorCode ? { error_code: params.errorCode } : {}),
+    });
   },
 
   /**


### PR DESCRIPTION
## Summary

Makes microphone problems in the AI panel measurable.

- **Records when someone opens the AI panel.** We previously only recorded what happened
  after they used it, so anyone who opened it and backed out left no trace.
- **Tells apart the different "no microphone" situations,** which all looked identical
  before. iOS only shows the mic popup once ever, so someone who declined it and then
  reopened the panel ten times was logged as ten refusals, rather than as one person
  stuck behind a wall they can't clear inside the app.

Two small fixes alongside: an error in the permission check itself logged nothing at all,
and closing the panel while the system popup was showing could bounce the user off the
screen they had returned to.

Nothing existing was renamed, so current data stays comparable.

## Release note

> _none_

**Status:**

- [ ] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [x] Internal only (refactor / infra / tests / CI / deps) — don't announce
