### PR TITLE
fix(voice): make the hold-to-talk mic responsive to real user behaviour

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -56,9 +56,9 @@ CI will not catch a mistake. `pr-release-note-check.yml` only greps for *any* `-
 5. **Apply the consistency rules.** These are the point of the skill.
    - All four Status lines present, **exactly one** ticked.
    - Release note `none` **if and only if** Internal or Hidden. Never `none` alongside User-facing or Beta.
-   - User-facing or Beta needs one sentence written as a **marketing announcement, not a changelog entry**. Lead with the high-level improvement being sold ("Improved the AI voice input experience…"), then at most one short clause narrowing the scope ("— the mic button is now faster and more reliable"). You are packaging and selling the improvement; a note that enumerates every behavioural detail buries the message and nobody can tell what is being announced. Details belong in the Summary, never here. Still no file names, no type names, no "refactored".
-     - Bad (too detailed): "The voice button now starts listening the instant you press it, short voice inputs are no longer lost, and an accidental tap clearly shows you need to hold."
-     - Good (marketing altitude): "Improved the AI voice input experience — the mic button now responds instantly and short recordings are no longer lost."
+   - User-facing or Beta needs one sentence written as a **marketing announcement, not a changelog entry**: name what got better at a high level, then at most one short clause of scope. Enumerating behavioural details buries what is being announced — details belong in the Summary, never here. Still no file names, no type names, no "refactored".
+     - Too detailed: "The voice button now starts listening the instant you press it, short voice inputs are no longer lost, and an accidental tap clearly shows you need to hold."
+     - Right altitude: "Improved the AI voice input experience — the mic button now responds instantly and short recordings are no longer lost."
    - Strip every `<!-- -->` comment from the template.
    - Keep the whole body tight. `preview-next-release.yml` truncates each body to **1500 characters** before the model sees it, and the template from `## Release note` down is 555 of those. That leaves roughly **900 characters** for the Summary; go over and the Status block is cut off, and the model falls back to guessing from the title.
 

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -56,7 +56,9 @@ CI will not catch a mistake. `pr-release-note-check.yml` only greps for *any* `-
 5. **Apply the consistency rules.** These are the point of the skill.
    - All four Status lines present, **exactly one** ticked.
    - Release note `none` **if and only if** Internal or Hidden. Never `none` alongside User-facing or Beta.
-   - User-facing or Beta needs one plain sentence a normal user would understand: no file names, no type names, no "refactored".
+   - User-facing or Beta needs one sentence written as a **marketing announcement, not a changelog entry**. Lead with the high-level improvement being sold ("Improved the AI voice input experience…"), then at most one short clause narrowing the scope ("— the mic button is now faster and more reliable"). You are packaging and selling the improvement; a note that enumerates every behavioural detail buries the message and nobody can tell what is being announced. Details belong in the Summary, never here. Still no file names, no type names, no "refactored".
+     - Bad (too detailed): "The voice button now starts listening the instant you press it, short voice inputs are no longer lost, and an accidental tap clearly shows you need to hold."
+     - Good (marketing altitude): "Improved the AI voice input experience — the mic button now responds instantly and short recordings are no longer lost."
    - Strip every `<!-- -->` comment from the template.
    - Keep the whole body tight. `preview-next-release.yml` truncates each body to **1500 characters** before the model sees it, and the template from `## Release note` down is 555 of those. That leaves roughly **900 characters** for the Summary; go over and the Status block is cut off, and the model falls back to guessing from the title.
 

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
@@ -4,7 +4,7 @@ import {
   useAudioRecorder,
   useAudioRecorderState,
 } from "expo-audio";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { File as ExpoFile } from "expo-file-system";
 import { useTranslation } from "react-i18next";
 import Toast from "react-native-toast-message";
@@ -15,17 +15,26 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
   const recorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);
   const { isRecording } = useAudioRecorderState(recorder);
 
-  // Pre-warm the audio session and recorder on mount: a cold prepare takes
-  // 300-650ms, which would otherwise be a dead window right after press-in
-  // where nothing is recorded yet.
-  useEffect(() => {
-    setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true })
-      .then(() => recorder.prepareToRecordAsync())
-      .catch((error) => console.warn("[Mic] Failed to pre-warm recorder.", error));
-  }, [recorder]);
   // Release handlers wait on this so they never race ahead of async recorder setup.
   const startPromiseRef = useRef<Promise<void> | null>(null);
   const cancelRequested = useRef(false);
+
+  const prepareRecorder = useCallback(async (): Promise<void> => {
+    await setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true });
+    await recorder.prepareToRecordAsync();
+  }, [recorder]);
+
+  // Pre-warm on mount: a cold prepare takes 300-650ms, which would otherwise be
+  // a dead window right after press-in where nothing is recorded yet. The
+  // recording audio mode is process-global, so hand it back on unmount.
+  useEffect(() => {
+    prepareRecorder().catch((error) => console.warn("[Mic] Failed to pre-warm recorder.", error));
+    return () => {
+      setAudioModeAsync({ allowsRecording: false, playsInSilentMode: true }).catch((error) =>
+        console.warn("[Mic] Failed to reset audio mode.", error),
+      );
+    };
+  }, [prepareRecorder]);
 
   const trackRecordingFailure = (errorCode: string) => {
     analytics.trackAiTaskGenerationFailed({
@@ -48,8 +57,7 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
 
   const startRecording = async (): Promise<void> => {
     try {
-      await setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true });
-      await recorder.prepareToRecordAsync();
+      await prepareRecorder();
       if (cancelRequested.current) return;
       recorder.record();
     } catch (error) {
@@ -63,13 +71,21 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
     cancelRequested.current = true;
     await startPromiseRef.current;
 
-    if (recorder.isRecording) {
-      try {
-        await recorder.stop();
-      } catch (error) {
-        console.warn("[Mic] Error cancelling recording.", error);
-        trackRecordingFailure("RecordingCancelFailed");
-      }
+    if (!recorder.isRecording) return;
+
+    try {
+      await recorder.stop();
+    } catch (error) {
+      console.warn("[Mic] Error cancelling recording.", error);
+      trackRecordingFailure("RecordingCancelFailed");
+      return;
+    }
+
+    // Best-effort cleanup of the discarded take, mirroring stopAndUpload.
+    try {
+      if (recorder.uri) new ExpoFile(recorder.uri).delete();
+    } catch (error) {
+      console.warn("[Mic] Failed to delete cancelled recording file.", error);
     }
   };
 

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
@@ -4,7 +4,7 @@ import {
   useAudioRecorder,
   useAudioRecorderState,
 } from "expo-audio";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { File as ExpoFile } from "expo-file-system";
 import { useTranslation } from "react-i18next";
 import Toast from "react-native-toast-message";
@@ -14,6 +14,15 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
   const { t } = useTranslation("aiTaskGenerate");
   const recorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);
   const { isRecording } = useAudioRecorderState(recorder);
+
+  // Pre-warm the audio session and recorder on mount: a cold prepare takes
+  // 300-650ms, which would otherwise be a dead window right after press-in
+  // where nothing is recorded yet.
+  useEffect(() => {
+    setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true })
+      .then(() => recorder.prepareToRecordAsync())
+      .catch((error) => console.warn("[Mic] Failed to pre-warm recorder.", error));
+  }, [recorder]);
   // Release handlers wait on this so they never race ahead of async recorder setup.
   const startPromiseRef = useRef<Promise<void> | null>(null);
   const cancelRequested = useRef(false);

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
@@ -19,9 +19,17 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
   const startPromiseRef = useRef<Promise<void> | null>(null);
   const cancelRequested = useRef(false);
 
+  // Android throws AudioRecorderAlreadyPreparedException on a second prepare
+  // (iOS silently re-prepares), so track prepared state and only prepare when
+  // needed. stop() releases the native recorder on Android, so the flag resets
+  // after every stop attempt.
+  const isPreparedRef = useRef(false);
+
   const prepareRecorder = useCallback(async (): Promise<void> => {
+    if (isPreparedRef.current) return;
     await setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true });
     await recorder.prepareToRecordAsync();
+    isPreparedRef.current = true;
   }, [recorder]);
 
   // Pre-warm on mount: a cold prepare takes 300-650ms, which would otherwise be
@@ -79,6 +87,8 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
       console.warn("[Mic] Error cancelling recording.", error);
       trackRecordingFailure("RecordingCancelFailed");
       return;
+    } finally {
+      isPreparedRef.current = false;
     }
 
     // Best-effort cleanup of the discarded take, mirroring stopAndUpload.
@@ -105,6 +115,8 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
       console.warn("[Mic] Error stopping recording.", error);
       trackRecordingFailure("RecordingStopFailed");
       return false;
+    } finally {
+      isPreparedRef.current = false;
     }
 
     const uri = recorder.uri;

--- a/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
@@ -13,7 +13,12 @@ import {
   useKeyboardState,
   useReanimatedKeyboardAnimation,
 } from "react-native-keyboard-controller";
-import Animated, { useAnimatedStyle } from "react-native-reanimated";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { LinearGradient } from "expo-linear-gradient";
 import MaterialCommunityIcons from "@react-native-vector-icons/material-design-icons/static";
@@ -39,6 +44,11 @@ import Toast from "react-native-toast-message";
 import { analytics } from "@/shared/services/analytics";
 import { toastConfig } from "@/shared/components/toast-config";
 
+// Presses shorter than this are treated as accidental taps and discarded;
+// anything longer is a real recording and gets uploaded.
+const MIN_HOLD_MS = 300;
+const HOLD_HINT_AUTO_HIDE_MS = 2500;
+
 export default function AiTaskSheetScreen() {
   // --- Hooks ---
   const { t } = useTranslation("aiTaskGenerate");
@@ -52,6 +62,16 @@ export default function AiTaskSheetScreen() {
   const longPressTriggered = useRef(false);
   const { isVisible: isKeyboardVisible } = useKeyboardState();
   const [isHoldHintVisible, setIsHoldHintVisible] = useState(false);
+  const micShakeX = useSharedValue(0);
+  const micShakeStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: micShakeX.value }],
+  }));
+
+  useEffect(() => {
+    if (!isHoldHintVisible) return;
+    const timer = setTimeout(() => setIsHoldHintVisible(false), HOLD_HINT_AUTO_HIDE_MS);
+    return () => clearTimeout(timer);
+  }, [isHoldHintVisible]);
 
   const { height: keyboardOffset } = useReanimatedKeyboardAnimation();
   const listKeyboardPad = useAnimatedStyle(() => ({
@@ -171,6 +191,21 @@ export default function AiTaskSheetScreen() {
     void startListening();
   };
 
+  // Accidental tap (released before MIN_HOLD_MS): shake the pill, buzz, and
+  // show the hold hint briefly so the discard is never silent.
+  const handleMicMisfire = () => {
+    void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+    micShakeX.value = withSequence(
+      withTiming(-8, { duration: 50 }),
+      withTiming(8, { duration: 50 }),
+      withTiming(-5, { duration: 50 }),
+      withTiming(5, { duration: 50 }),
+      withTiming(0, { duration: 50 }),
+    );
+    setIsHoldHintVisible(true);
+    void cancelListening();
+  };
+
   const handleMicPressOut = async () => {
     const didSubmit = await stopAndUpload();
     if (didSubmit) {
@@ -273,50 +308,54 @@ export default function AiTaskSheetScreen() {
                   {/* Voice mode: hold-to-talk pill (waveform while recording). Text mode: input. */}
                   <View className="flex-1 items-center justify-center">
                     {inputMode === "voice" ? (
-                      <Pressable
-                        onPressIn={() => {
-                          void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-                          longPressTriggered.current = false;
-                          handleMicPressIn();
-                        }}
-                        onPressOut={() => {
-                          if (!longPressTriggered.current) {
-                            setIsHoldHintVisible(true);
-                            void cancelListening();
-                          } else {
-                            void handleMicPressOut();
-                          }
-                        }}
-                        onLongPress={() => {
-                          longPressTriggered.current = true;
-                        }}
-                        delayLongPress={1000}
-                        className="w-full h-14 rounded-full flex-row items-center justify-center gap-2"
-                        style={{
-                          backgroundColor: isRecording
-                            ? "rgba(255,255,255,0.5)"
-                            : "rgba(255,255,255,0.25)",
-                          opacity: isAiGenerating ? 0.4 : 1,
-                        }}
-                        disabled={isAiGenerating}
-                      >
-                        {isRecording ? (
-                          <LottieView
-                            source={LOTTIE_ANIMATIONS.voiceWave}
-                            loop
-                            autoPlay
-                            style={{ width: "100%", height: 40 }}
-                            resizeMode="contain"
-                          />
-                        ) : (
-                          <>
-                            <MaterialCommunityIcons name="microphone" size={24} color="white" />
-                            <Text className="text-white font-baloo text-base">
-                              {t("buttons.holdToTalk")}
-                            </Text>
-                          </>
-                        )}
-                      </Pressable>
+                      <Animated.View className="w-full" style={micShakeStyle}>
+                        <Pressable
+                          onPressIn={() => {
+                            void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+                            longPressTriggered.current = false;
+                            handleMicPressIn();
+                          }}
+                          onPressOut={() => {
+                            if (!longPressTriggered.current) {
+                              handleMicMisfire();
+                            } else {
+                              void handleMicPressOut();
+                            }
+                          }}
+                          onLongPress={() => {
+                            longPressTriggered.current = true;
+                          }}
+                          delayLongPress={MIN_HOLD_MS}
+                          className="w-full h-14 rounded-full flex-row items-center justify-center gap-2"
+                          style={({ pressed }) => ({
+                            // `pressed` lights the pill up immediately on touch, before
+                            // the recorder state catches up.
+                            backgroundColor:
+                              isRecording || pressed
+                                ? "rgba(255,255,255,0.5)"
+                                : "rgba(255,255,255,0.25)",
+                            opacity: isAiGenerating ? 0.4 : 1,
+                          })}
+                          disabled={isAiGenerating}
+                        >
+                          {isRecording ? (
+                            <LottieView
+                              source={LOTTIE_ANIMATIONS.voiceWave}
+                              loop
+                              autoPlay
+                              style={{ width: "100%", height: 40 }}
+                              resizeMode="contain"
+                            />
+                          ) : (
+                            <>
+                              <MaterialCommunityIcons name="microphone" size={24} color="white" />
+                              <Text className="text-white font-baloo text-base">
+                                {t("buttons.holdToTalk")}
+                              </Text>
+                            </>
+                          )}
+                        </Pressable>
+                      </Animated.View>
                     ) : (
                       <TextInput
                         autoFocus

--- a/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
@@ -41,6 +41,7 @@ import { mapRecurringToCreateDTO } from "../utils/map-recurring-to-create-dto";
 import useTaskMutations from "@/shared/hooks/useTaskMutations";
 import { useNotesMutation } from "@/feature/notes/hooks/useNotesMutation";
 import Toast from "react-native-toast-message";
+import { useDebouncedCallback } from "use-debounce";
 import { analytics } from "@/shared/services/analytics";
 import { toastConfig } from "@/shared/components/toast-config";
 
@@ -59,19 +60,17 @@ export default function AiTaskSheetScreen() {
   // Interface opens in voice mode by default; the keyboard toggle switches to text.
   const [inputMode, setInputMode] = useState<"voice" | "text">("voice");
   const hasSubmittedAiRequest = useRef(false);
-  const longPressTriggered = useRef(false);
+  const heldLongEnough = useRef(false);
   const { isVisible: isKeyboardVisible } = useKeyboardState();
   const [isHoldHintVisible, setIsHoldHintVisible] = useState(false);
+  const hideHoldHintLater = useDebouncedCallback(
+    () => setIsHoldHintVisible(false),
+    HOLD_HINT_AUTO_HIDE_MS,
+  );
   const micShakeX = useSharedValue(0);
   const micShakeStyle = useAnimatedStyle(() => ({
     transform: [{ translateX: micShakeX.value }],
   }));
-
-  useEffect(() => {
-    if (!isHoldHintVisible) return;
-    const timer = setTimeout(() => setIsHoldHintVisible(false), HOLD_HINT_AUTO_HIDE_MS);
-    return () => clearTimeout(timer);
-  }, [isHoldHintVisible]);
 
   const { height: keyboardOffset } = useReanimatedKeyboardAnimation();
   const listKeyboardPad = useAnimatedStyle(() => ({
@@ -160,7 +159,12 @@ export default function AiTaskSheetScreen() {
         // Fire per successful task, not behind the all-succeed gate below, so a partial
         // failure still records the tasks that did land.
         const taskId = await addTaskAsync(convertAiTaskToTaskUpsertDTO(task));
-        analytics.trackTaskCreated({ taskId, source: "ai", isRecurring: false, hasDeadline: false });
+        analytics.trackTaskCreated({
+          taskId,
+          source: "ai",
+          isRecurring: false,
+          hasDeadline: false,
+        });
       }),
       ...displayRecurringTasks.map(async (task) => {
         const { recurringTaskId } = await createRecurringTaskAsync(mapRecurringToCreateDTO(task));
@@ -187,30 +191,41 @@ export default function AiTaskSheetScreen() {
   };
 
   const handleMicPressIn = () => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    heldLongEnough.current = false;
+    hideHoldHintLater.cancel();
     setIsHoldHintVisible(false);
     void startListening();
   };
 
-  // Accidental tap (released before MIN_HOLD_MS): shake the pill, buzz, and
-  // show the hold hint briefly so the discard is never silent.
+  // Released before MIN_HOLD_MS: discard, but never silently.
   const handleMicMisfire = () => {
     void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
     micShakeX.value = withSequence(
-      withTiming(-8, { duration: 50 }),
-      withTiming(8, { duration: 50 }),
-      withTiming(-5, { duration: 50 }),
-      withTiming(5, { duration: 50 }),
-      withTiming(0, { duration: 50 }),
+      ...[-8, 8, -5, 5, 0].map((x) => withTiming(x, { duration: 50 })),
     );
     setIsHoldHintVisible(true);
+    hideHoldHintLater();
     void cancelListening();
   };
 
-  const handleMicPressOut = async () => {
+  const handleMicSubmit = async () => {
     const didSubmit = await stopAndUpload();
     if (didSubmit) {
       hasSubmittedAiRequest.current = true;
     }
+  };
+
+  const handleMicRelease = () => {
+    if (heldLongEnough.current) {
+      void handleMicSubmit();
+    } else {
+      handleMicMisfire();
+    }
+  };
+
+  const markHeldLongEnough = () => {
+    heldLongEnough.current = true;
   };
 
   const handleSwitchToText = () => {
@@ -306,56 +321,45 @@ export default function AiTaskSheetScreen() {
                   </Pressable>
 
                   {/* Voice mode: hold-to-talk pill (waveform while recording). Text mode: input. */}
-                  <View className="flex-1 items-center justify-center">
+                  <Animated.View
+                    className="flex-1 items-center justify-center"
+                    style={micShakeStyle}
+                  >
                     {inputMode === "voice" ? (
-                      <Animated.View className="w-full" style={micShakeStyle}>
-                        <Pressable
-                          onPressIn={() => {
-                            void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-                            longPressTriggered.current = false;
-                            handleMicPressIn();
-                          }}
-                          onPressOut={() => {
-                            if (!longPressTriggered.current) {
-                              handleMicMisfire();
-                            } else {
-                              void handleMicPressOut();
-                            }
-                          }}
-                          onLongPress={() => {
-                            longPressTriggered.current = true;
-                          }}
-                          delayLongPress={MIN_HOLD_MS}
-                          className="w-full h-14 rounded-full flex-row items-center justify-center gap-2"
-                          style={({ pressed }) => ({
-                            // `pressed` lights the pill up immediately on touch, before
-                            // the recorder state catches up.
-                            backgroundColor:
-                              isRecording || pressed
-                                ? "rgba(255,255,255,0.5)"
-                                : "rgba(255,255,255,0.25)",
-                            opacity: isAiGenerating ? 0.4 : 1,
-                          })}
-                          disabled={isAiGenerating}
-                        >
-                          {isRecording ? (
-                            <LottieView
-                              source={LOTTIE_ANIMATIONS.voiceWave}
-                              loop
-                              autoPlay
-                              style={{ width: "100%", height: 40 }}
-                              resizeMode="contain"
-                            />
-                          ) : (
-                            <>
-                              <MaterialCommunityIcons name="microphone" size={24} color="white" />
-                              <Text className="text-white font-baloo text-base">
-                                {t("buttons.holdToTalk")}
-                              </Text>
-                            </>
-                          )}
-                        </Pressable>
-                      </Animated.View>
+                      <Pressable
+                        onPressIn={handleMicPressIn}
+                        onPressOut={handleMicRelease}
+                        onLongPress={markHeldLongEnough}
+                        delayLongPress={MIN_HOLD_MS}
+                        className="w-full h-14 rounded-full flex-row items-center justify-center gap-2"
+                        style={({ pressed }) => ({
+                          // `pressed` lights the pill up immediately on touch, before
+                          // the recorder state catches up.
+                          backgroundColor:
+                            isRecording || pressed
+                              ? "rgba(255,255,255,0.5)"
+                              : "rgba(255,255,255,0.25)",
+                          opacity: isAiGenerating ? 0.4 : 1,
+                        })}
+                        disabled={isAiGenerating}
+                      >
+                        {isRecording ? (
+                          <LottieView
+                            source={LOTTIE_ANIMATIONS.voiceWave}
+                            loop
+                            autoPlay
+                            style={{ width: "100%", height: 40 }}
+                            resizeMode="contain"
+                          />
+                        ) : (
+                          <>
+                            <MaterialCommunityIcons name="microphone" size={24} color="white" />
+                            <Text className="text-white font-baloo text-base">
+                              {t("buttons.holdToTalk")}
+                            </Text>
+                          </>
+                        )}
+                      </Pressable>
                     ) : (
                       <TextInput
                         autoFocus
@@ -370,7 +374,7 @@ export default function AiTaskSheetScreen() {
                         className={`w-full text-white font-baloo text-base px-4 bg-white/25 rounded-full h-14 ${isAiGenerating ? "opacity-40" : "opacity-100"}`}
                       />
                     )}
-                  </View>
+                  </Animated.View>
                 </View>
                 {hasContent && !isKeyboardVisible && (
                   <Pressable


### PR DESCRIPTION
## Summary

Users tapped the mic on the AI task sheet, started speaking, and nothing happened. Three measured causes, all fixed:

- **A tap never started recording** — cold recorder prep (300–650 ms) outlived the tap itself, and the only feedback was a permanent grey hint line. The recorder is now pre-warmed when the sheet opens; press-to-recording drops to 22–64 ms, which also stops the first words being swallowed.
- **Holds under 1 s were silently discarded**, losing short phrases the mic had already captured. The minimum-hold gate is now 300 ms and only filters accidental taps.
- **Weak feedback** — a misfire now shakes the pill with a warning haptic, the hint auto-hides after 2.5 s, and the pill lights up the instant it is pressed.

Verified end-to-end in the iOS simulator (gesture injection + timestamped logs at every state transition).

## Release note

> Improved the AI voice input experience — the mic button now responds instantly and short recordings are no longer lost.

**Status:**

- [x] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce
