### PR TITLE
fix(voice): stop Whisper inventing tasks from silence, restore mic haptics

### DIFF
--- a/.claude/skills/real-device-test/SKILL.md
+++ b/.claude/skills/real-device-test/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: real-device-test
+description: Use when the user wants something verified on a physical phone — "真机测试一下", "test this on my iPhone", "check it on a real device", "run it on my phone" — or wants the AI to drive the installed app on a USB-connected iPhone/Android and report what it saw.
+---
+
+# Real-device test
+
+Drive the Blotz dev build on a **physical phone** with `agent-device`, then report evidence (screenshots, UI tree, logs), not opinions. Validated on iPhone 2026-09-10; Android uses the same tool but has not been run in this project yet — say so if you use it.
+
+**Never** silently fall back to the simulator and call it a device pass. If the phone is unreachable, report the blocker.
+
+## 0. Readiness gate — run it every time, in this order
+
+Walk the checklist top to bottom. For each item: run the check; if it fails, apply the fix if the AI can, otherwise give the user the exact step and **wait** for them to say it's done. Do not start §4 until every row is ✅. Tell the user which rows passed and which are pending so they always know what is being waited on.
+
+| # | Check (AI runs) | Passes when | If it fails |
+|---|---|---|---|
+| 1 | `agent-device --version` | prints a version | AI: `npm install -g agent-device@latest` (needs Node 22.12+; the project's Node 22 is fine) |
+| 2 | `DevToolsSecurity -status` | "enabled" | **User**, in their own terminal: `sudo DevToolsSecurity -enable` (Mac password). agent-device's error for this says "Developer mode is disabled" — it means the **Mac**, not the phone |
+| 3 | `xcrun devicectl list devices` | the phone is listed as `available` | **User**: plug the phone in with a **data** cable, unlock it, tap **Trust** on the phone. If it stays `unavailable`, AI runs `xcrun devicectl manage pair --device <CoreDevice id>` which pops the Trust prompt |
+| 4 | `xcrun devicectl device info details --device <CoreDevice id>` → `developerModeStatus` | `enabled` | **User**: Settings → Privacy & Security → Developer Mode → on → phone restarts → confirm "Turn On". (The toggle only appears after step 3) |
+| 5 | same command → note `udid` (`00008…`) and `osVersionNumber` | recorded for the report | — |
+| 6 | `xcrun devicectl device info apps --device <CoreDevice id> \| grep -i com.Blotz.BlotzTask.dev` | the dev build is installed | see **§1 Getting the dev build onto this phone** — the only step that may need Ben |
+| 7 | native change since that build? (`git log` / `git status` touching `modules/`, `app.config.js` plugins, a library with native code, `expo prebuild` output) | no | rebuild per §1; JS/TS/style changes never need this |
+| 8 | Apple signing for the **agent-device runner**: `xcrun devicectl … details` shows the phone; then try `agent-device open …` in §4 | runner builds and installs | Ben's Mac: `export AGENT_DEVICE_IOS_TEAM_ID=Z6GFDAYSP9`. Anyone else: sign into Xcode (Xcode → Settings → Apple Accounts) with **any** Apple ID — a free Personal Team is enough for the runner — and export that team's id instead (find it under the account's "Developer Team" in that settings page). Free signing expires after 7 days; the runner just rebuilds |
+| 9 | backend chosen (§2) and Metro serving the phone (§3) | `iOS Bundled …` line in the Metro log after launch | fix per §3 |
+| 10 | phone is logged in (§4 snapshot shows the Today screen, not "Continue with Phone") | logged in as **blotztest1@gmail.com** | **User** logs in on the phone; never search for the password. If another account is signed in: Settings → Log out first (Auth0 remembers the last account) |
+
+Android equivalents: `adb devices -l` (USB debugging on, "Allow this computer" tapped), package `com.blotz.blotztask`, `agent-device … --platform android --serial <serial>`. Rows 2, 4 and 8 do not apply.
+
+## 1. Getting the dev build onto this phone
+
+The dev build is bundle id `com.Blotz.BlotzTask.dev`. It coexists with the App Store app — never install over `com.Blotz.BlotzTask`.
+
+Apple only lets a development build run on phones **registered under the Blotz Apple team (`Z6GFDAYSP9`)**, and that team is an Individual account, so **only Ben can register a phone and only Ben's Mac can sign the app**. That is the one place a teammate depends on Ben; it happens once per phone (about 10 minutes on Ben's side, and several phones can be batched).
+
+**Teammates — EAS path.** Tell the user to ask Ben for the two things below; do not try to work around Apple signing.
+1. Ben runs `eas device:create` → chooses **Website** → sends the registration link. The teammate opens it **on the phone** and taps through; the UDID registers itself, nobody types it.
+2. Ben runs `eas build --profile development --platform ios` and shares the install link. The teammate installs from it. The profile in `eas.json` already sets the `.dev` bundle id and the staging backend.
+Repeat step 2 only when native code changes (row 7). JS changes come from the teammate's own Metro (§3).
+
+**Ben's Mac — local build** (Xcode signed into team Z6GFDAYSP9):
+```bash
+cd blotztask-mobile
+BUNDLE_IDENTIFIER=com.Blotz.BlotzTask.dev npx expo prebuild --platform ios --clean
+cd ios && xcodebuild -workspace BlotzTask.xcworkspace -scheme BlotzTask -configuration Debug \
+  -destination 'id=<UDID>' -allowProvisioningUpdates -allowProvisioningDeviceRegistration build
+xcrun devicectl device install app --device <CoreDevice id> \
+  ~/Library/Developer/Xcode/DerivedData/BlotzTask-*/Build/Products/Debug-iphoneos/BlotzTask.app
+```
+`-destination 'id=<UDID>'` matters: a `generic/platform=iOS` build does not register the phone in the profile and the install fails. `prebuild --clean` regenerates the gitignored `ios/` — warn any parallel session, and always pass `BUNDLE_IDENTIFIER` or the simulator build's bundle id changes too.
+
+## 2. Choose the backend — one question, with a recommendation
+
+`localhost` in `blotztask-mobile/.env` is the **phone itself**, so the phone can never reach the API through it. Two working options:
+
+| Backend | When | Metro env |
+|---|---|---|
+| **staging** — recommend for teammates and UI-only changes | nothing needed locally | `EXPO_PUBLIC_URL=https://app-blotz-task-api-stag.azurewebsites.net/ EXPO_PUBLIC_URL_WITH_API=https://app-blotz-task-api-stag.azurewebsites.net/api` |
+| **local** — cross-stack changes | API started with `--urls http://0.0.0.0:5027`, SQL container up | `EXPO_PUBLIC_URL=http://<Mac LAN IP>:5027 EXPO_PUBLIC_URL_WITH_API=http://<Mac LAN IP>:5027/api` |
+
+Detect: `lsof -nP -iTCP:5027 -sTCP:LISTEN` → if something is listening, offer local, otherwise recommend staging. The dev build allows plain HTTP to the LAN (`NSAllowsLocalNetworking`), so no ATS change is needed. Mac LAN IP: `ipconfig getifaddr en0`; phone and Mac must be on the same Wi-Fi.
+
+**Local backend + login:** users are registered by an Auth0 post-login webhook that only reaches hosted backends. The account the phone signs in with must already exist in the local `AppUsers` table, or every request 401s with "User is not registered in this app" and the app logs itself out. The seeded test account **blotztest1@gmail.com** exists locally and on staging — use it. A missing `PomodoroSettings` row shows as a 404 toast — insert one, don't debug the app.
+
+## 3. Metro and launch
+
+Port **8082** so it never collides with a simulator session on 8081. No `CI=1` (it disables Fast Refresh).
+
+```bash
+cd blotztask-mobile
+<backend env from §2> nohup npx expo start --dev-client --port 8082 --non-interactive < /dev/null > /tmp/metro-8082.log 2>&1 &
+xcrun devicectl device process launch --device <CoreDevice id> --terminate-existing \
+  --payload-url "blotztask://expo-development-client/?url=http%3A%2F%2F<Mac LAN IP>%3A8082" com.Blotz.BlotzTask.dev
+grep "iOS Bundled" /tmp/metro-8082.log     # proves the phone pulled the bundle from *this* Metro
+```
+
+The dev client tries whatever is on 8081 first before honouring the URL; a stale bundle looks like `AxiosError: Network Error` on a Loading screen. Relaunch with the command above. Re-run the launch command whenever you need a cold start (persistence checks).
+
+## 4. Drive the phone
+
+```bash
+export AGENT_DEVICE_IOS_TEAM_ID=<team id from row 8>   # first run builds the XCTest runner (~1 min)
+agent-device open com.Blotz.BlotzTask.dev --platform ios --udid <UDID>   # always pass --udid: the tool prefers simulators
+agent-device snapshot -i                          # UI tree with @eN refs — read this before every action
+agent-device press @e12 | press <x> <y>           # tap by ref or by points
+agent-device fill @e13 "text"                     # replaces the field's text; press the keyboard "done" ref after
+agent-device screenshot ./artifacts/<step>.png
+agent-device logs start … logs stop … logs path   # device log for the window you care about
+agent-device close
+```
+
+Runner build fails with `Build input file cannot be found: …mobileprovision` → `rm -rf ~/.agent-device/apple-runner/derived/ios-device` and retry.
+
+## 5. Report format
+
+For each scenario: device (name, iOS version), build (bundle id, backend used, Metro "Bundled" line), then steps as **pass / fail / not verified**, each with the screenshot path and the log lines that justify it. A tap that "succeeded" is not a pass — the pass is the observable result (count changed, row in DB, still there after a cold start). Say explicitly what could not be exercised on hardware (camera, biometrics, background time, TestFlight-only behaviour).
+
+## Known gotchas — environment, not product bugs
+
+| Symptom | Cause / fix |
+|---|---|
+| Tapping the top-right "Skip" does nothing | the dev-client floating gear button sits over it; use "Continue" or other elements |
+| The "+" add-task tab is not in the UI tree | it has no accessibility label; screenshot and tap by points (centre of the 4th tab icon) |
+| Create Task form: title field has no label | it is the first editable `text-field`; the bottom "Create Task" node is the save button |
+| 401 "User is not registered in this app" | local DB lacks the account — see §2 |
+| 404 "Pomodoro setting … not found" | local DB lacks the row for that user — insert, don't debug |
+| `AxiosError: Network Error` on Loading | bundle came from the wrong Metro (8081) → relaunch per §3 |
+| Runner error "Developer mode is disabled" | Mac `DevToolsSecurity` (row 2), not the phone |
+| `expo-notifications` push-token WARN in Metro | dev builds have no push entitlement; ignore |
+| Chinese/emoji input on Android | agent-device uses a test IME (`--test-ime`); verify keyboard UX manually, never change product validation to suit the tool |

--- a/blotztask-api/Modules/ChatTaskGenerator/Services/NoSpeechTranscripts.cs
+++ b/blotztask-api/Modules/ChatTaskGenerator/Services/NoSpeechTranscripts.cs
@@ -1,0 +1,49 @@
+namespace BlotzTask.Modules.ChatTaskGenerator.Services;
+
+/// <summary>
+/// Text Whisper returns for audio with no speech ("Thank you.", "谢谢大家", like-and-subscribe
+/// pleas from its subtitle training data). Groq's turbo model gives no_speech_prob = 0 for
+/// silence, so the text itself is the only signal.
+/// </summary>
+public static class NoSpeechTranscripts
+{
+    // Compared after Normalize().
+    private static readonly HashSet<string> ExactPhrases = new(StringComparer.Ordinal)
+    {
+        "thankyou",
+        "thanks",
+        "thankyouforwatching",
+        "thanksforwatching",
+        "thankyousomuch",
+        "thankyouverymuch",
+        "you",
+        "bye",
+        "谢谢",
+        "谢谢大家",
+        "谢谢观看",
+        "谢谢收看",
+        "感谢观看",
+        "感谢收看",
+        "多谢",
+    };
+
+    // Wording drifts; match the stable part. Also normalised.
+    private static readonly string[] Markers =
+    [
+        "明镜与点点", // "请不吝点赞 订阅 转发 打赏支持明镜与点点栏目"
+        "amaraorg",   // "字幕由 Amara.org 社区提供"
+    ];
+
+    public static bool Matches(string transcript)
+    {
+        var normalized = Normalize(transcript);
+
+        return normalized.Length == 0
+               || ExactPhrases.Contains(normalized)
+               || Markers.Any(normalized.Contains);
+    }
+
+    // Letters and digits only, lower-cased.
+    private static string Normalize(string text) =>
+        string.Concat(text.Where(char.IsLetterOrDigit)).ToLowerInvariant();
+}

--- a/blotztask-api/Modules/ChatTaskGenerator/Services/SpeechTranscriptionService.cs
+++ b/blotztask-api/Modules/ChatTaskGenerator/Services/SpeechTranscriptionService.cs
@@ -6,37 +6,6 @@ namespace BlotzTask.Modules.ChatTaskGenerator.Services;
 
 public class SpeechTranscriptionService(AudioClient audioClient, ILogger<SpeechTranscriptionService> logger)
 {
-    // Whisper was trained on subtitled video, so audio with no speech in it comes back as the
-    // captions that sat under silent footage: "Thank you.", "谢谢大家", a channel's like-and-subscribe
-    // plea. Groq's whisper-large-v3-turbo reports no_speech_prob = 0 for pure silence, so these
-    // phrases are the only server-side signal. The app meters the mic first; this is the backstop.
-    // Compared after stripping everything but letters and digits, case-insensitively.
-    private static readonly HashSet<string> NoSpeechTranscripts = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "thankyou",
-        "thanks",
-        "thankyouforwatching",
-        "thanksforwatching",
-        "thankyousomuch",
-        "thankyouverymuch",
-        "you",
-        "bye",
-        "谢谢",
-        "谢谢大家",
-        "谢谢观看",
-        "谢谢收看",
-        "感谢观看",
-        "感谢收看",
-        "多谢",
-    };
-
-    // Longer boilerplate varies in wording, so match on the part that never changes.
-    private static readonly string[] NoSpeechMarkers =
-    [
-        "明镜与点点",      // "请不吝点赞 订阅 转发 打赏支持明镜与点点栏目"
-        "amara.org",       // "字幕由 Amara.org 社区提供"
-    ];
-
     public async Task<string> TranscribeAsync(IFormFile audio, CancellationToken ct = default)
     {
         if (audio.Length <= 0)
@@ -44,31 +13,14 @@ public class SpeechTranscriptionService(AudioClient audioClient, ILogger<SpeechT
 
         var transcript = await RequestTranscriptAsync(audio, ct);
 
-        if (IsNoSpeechTranscript(transcript))
+        // Backstop behind the app's mic-level gate.
+        if (NoSpeechTranscripts.Matches(transcript))
         {
-            logger.LogInformation("Transcript matched a known no-speech phrase; treating as empty audio. Transcript: {Transcript}",
-                transcript);
+            logger.LogInformation("Transcript is a known no-speech phrase, treating as empty audio: {Transcript}", transcript);
             throw new AiTaskGenerationException(AiErrorCode.EmptyAudio, "No speech was detected in the audio.");
         }
 
         return transcript;
-    }
-
-    /// <summary>
-    /// True when the transcript is one of the phrases Whisper produces for audio that holds no speech.
-    /// </summary>
-    public static bool IsNoSpeechTranscript(string transcript)
-    {
-        var normalized = new string(transcript.Where(char.IsLetterOrDigit).ToArray());
-
-        if (normalized.Length == 0)
-            return true;
-
-        if (NoSpeechTranscripts.Contains(normalized))
-            return true;
-
-        var lowered = transcript.ToLowerInvariant();
-        return NoSpeechMarkers.Any(marker => lowered.Contains(marker, StringComparison.OrdinalIgnoreCase));
     }
 
     private async Task<string> RequestTranscriptAsync(IFormFile audio, CancellationToken ct)

--- a/blotztask-api/Modules/ChatTaskGenerator/Services/SpeechTranscriptionService.cs
+++ b/blotztask-api/Modules/ChatTaskGenerator/Services/SpeechTranscriptionService.cs
@@ -6,11 +6,73 @@ namespace BlotzTask.Modules.ChatTaskGenerator.Services;
 
 public class SpeechTranscriptionService(AudioClient audioClient, ILogger<SpeechTranscriptionService> logger)
 {
+    // Whisper was trained on subtitled video, so audio with no speech in it comes back as the
+    // captions that sat under silent footage: "Thank you.", "谢谢大家", a channel's like-and-subscribe
+    // plea. Groq's whisper-large-v3-turbo reports no_speech_prob = 0 for pure silence, so these
+    // phrases are the only server-side signal. The app meters the mic first; this is the backstop.
+    // Compared after stripping everything but letters and digits, case-insensitively.
+    private static readonly HashSet<string> NoSpeechTranscripts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "thankyou",
+        "thanks",
+        "thankyouforwatching",
+        "thanksforwatching",
+        "thankyousomuch",
+        "thankyouverymuch",
+        "you",
+        "bye",
+        "谢谢",
+        "谢谢大家",
+        "谢谢观看",
+        "谢谢收看",
+        "感谢观看",
+        "感谢收看",
+        "多谢",
+    };
+
+    // Longer boilerplate varies in wording, so match on the part that never changes.
+    private static readonly string[] NoSpeechMarkers =
+    [
+        "明镜与点点",      // "请不吝点赞 订阅 转发 打赏支持明镜与点点栏目"
+        "amara.org",       // "字幕由 Amara.org 社区提供"
+    ];
+
     public async Task<string> TranscribeAsync(IFormFile audio, CancellationToken ct = default)
     {
         if (audio.Length <= 0)
             throw new ArgumentException("Audio file cannot be empty.", nameof(audio));
 
+        var transcript = await RequestTranscriptAsync(audio, ct);
+
+        if (IsNoSpeechTranscript(transcript))
+        {
+            logger.LogInformation("Transcript matched a known no-speech phrase; treating as empty audio. Transcript: {Transcript}",
+                transcript);
+            throw new AiTaskGenerationException(AiErrorCode.EmptyAudio, "No speech was detected in the audio.");
+        }
+
+        return transcript;
+    }
+
+    /// <summary>
+    /// True when the transcript is one of the phrases Whisper produces for audio that holds no speech.
+    /// </summary>
+    public static bool IsNoSpeechTranscript(string transcript)
+    {
+        var normalized = new string(transcript.Where(char.IsLetterOrDigit).ToArray());
+
+        if (normalized.Length == 0)
+            return true;
+
+        if (NoSpeechTranscripts.Contains(normalized))
+            return true;
+
+        var lowered = transcript.ToLowerInvariant();
+        return NoSpeechMarkers.Any(marker => lowered.Contains(marker, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private async Task<string> RequestTranscriptAsync(IFormFile audio, CancellationToken ct)
+    {
         try
         {
             await using var stream = audio.OpenReadStream();

--- a/blotztask-mobile/src/feature/ai-task-generate/component/hold-to-talk-pill.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/component/hold-to-talk-pill.tsx
@@ -1,0 +1,87 @@
+import { Pressable, Text } from "react-native";
+import Animated from "react-native-reanimated";
+import LottieView from "lottie-react-native";
+import MaterialCommunityIcons from "@react-native-vector-icons/material-design-icons/static";
+import { useTranslation } from "react-i18next";
+import { LOTTIE_ANIMATIONS } from "@/shared/constants/assets";
+
+const IDLE_FG = "#2F80ED";
+const ACTIVE_BG = "#9AD513"; // waveform Lottie is white, needs a coloured ground
+
+const shadow = {
+  shadowColor: "#000",
+  shadowOpacity: 0.18,
+  shadowRadius: 8,
+  shadowOffset: { width: 0, height: 4 },
+  elevation: 5,
+} as const;
+
+type Props = {
+  isRecording: boolean;
+  disabled: boolean;
+  minHoldMs: number;
+  onPressIn: () => void;
+  onPressOut: () => void;
+  onHeldLongEnough: () => void;
+};
+
+export function HoldToTalkPill({
+  isRecording,
+  disabled,
+  minHoldMs,
+  onPressIn,
+  onPressOut,
+  onHeldLongEnough,
+}: Props) {
+  const { t } = useTranslation("aiTaskGenerate");
+
+  return (
+    <Pressable
+      onPressIn={onPressIn}
+      onPressOut={onPressOut}
+      onLongPress={onHeldLongEnough}
+      delayLongPress={minHoldMs}
+      pressRetentionOffset={24}
+      className="w-full"
+      disabled={disabled}
+    >
+      {({ pressed }) => {
+        // `pressed` lands on the touch frame; isRecording lags behind recorder setup.
+        const isActive = isRecording || pressed;
+        const fg = isActive ? "white" : IDLE_FG;
+        return (
+          <Animated.View
+            className="w-full h-14 rounded-full flex-row items-center justify-center gap-2"
+            style={[
+              shadow,
+              {
+                backgroundColor: isActive ? ACTIVE_BG : "white",
+                opacity: disabled ? 0.5 : 1,
+                transform: [{ scale: pressed ? 0.97 : 1 }],
+                transitionProperty: ["transform", "backgroundColor"],
+                transitionDuration: 120,
+              },
+            ]}
+          >
+            {isRecording ? (
+              <LottieView
+                source={LOTTIE_ANIMATIONS.voiceWave}
+                loop
+                autoPlay
+                style={{ width: "100%", height: 40 }}
+                resizeMode="contain"
+              />
+            ) : (
+              <>
+                <MaterialCommunityIcons name="microphone" size={24} color={fg} />
+                <Text className="font-balooBold text-base" style={{ color: fg }}>
+                  {t("buttons.holdToTalk")}
+                </Text>
+              </>
+            )}
+          </Animated.View>
+        );
+      }}
+    </Pressable>
+  );
+}

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useAiTaskGenerator.ts
@@ -194,7 +194,7 @@ export function useAiTaskGenerator({
     requestStartedAtRef.current = null;
     const inputMode = pendingInputModeRef.current;
     pendingInputModeRef.current = null;
-    if (error.errorCode !== "QuotaExceeded") {
+    if (error.errorCode !== "QuotaExceeded" && error.errorCode !== "EmptyAudio") {
       setStreamedTasks([]);
       setStreamedNotes([]);
       setStreamedRecurringTasks([]);

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/usePeakLevelMeter.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/usePeakLevelMeter.ts
@@ -1,0 +1,32 @@
+import type { AudioRecorder } from "expo-audio";
+import { useEffect, useRef } from "react";
+
+const POLL_MS = 100;
+
+/** Loudest metering value (dBFS) during a take. Polls into a ref so the ticks don't re-render. */
+export function usePeakLevelMeter(recorder: AudioRecorder) {
+  const peakRef = useRef(Number.NEGATIVE_INFINITY);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stop = () => {
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  };
+
+  const start = () => {
+    stop();
+    peakRef.current = Number.NEGATIVE_INFINITY;
+    intervalRef.current = setInterval(() => {
+      const status = recorder.getStatus();
+      // iOS meters 0 dB while idle; only trust a live take.
+      if (!status.isRecording || status.metering === undefined) return;
+      peakRef.current = Math.max(peakRef.current, status.metering);
+    }, POLL_MS);
+  };
+
+  useEffect(() => stop, []);
+
+  return { start, stop, peakDbfs: () => peakRef.current };
+}

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
@@ -169,8 +169,6 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
       return false;
     }
 
-    if (__DEV__) console.log(`[Mic] Peak level ${peakLevelRef.current.toFixed(1)} dBFS.`);
-
     // Nothing loud enough to be speech: don't let Whisper make something up.
     if (peakLevelRef.current < SPEECH_LEVEL_DBFS) {
       Toast.show({ type: "error", text1: t("errors.emptyAudio") });

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
@@ -10,10 +10,23 @@ import { useTranslation } from "react-i18next";
 import Toast from "react-native-toast-message";
 import { analytics } from "@/shared/services/analytics";
 
+// Whisper invents text ("Thank you.") when the audio holds no speech, so a take whose loudest
+// moment never rises above this level is discarded before upload. Metering is dBFS on both
+// platforms (iOS averagePower, Android converted from maxAmplitude). Measured on an iPhone
+// 2026-09-10: a quiet room reads about -51, speech played from a laptop across the desk -42 to -35,
+// speech at max volume -15. -45 sits between silence and quiet speech; tune from the dev log below.
+const SPEECH_LEVEL_DBFS = -45;
+const METER_POLL_MS = 100;
+
 export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => Promise<void>) {
   const { t } = useTranslation("aiTaskGenerate");
-  const recorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);
+  const recorder = useAudioRecorder({ ...RecordingPresets.HIGH_QUALITY, isMeteringEnabled: true });
   const { isRecording } = useAudioRecorderState(recorder);
+
+  // Loudest level seen during the current take. Polled into a ref rather than through
+  // useAudioRecorderState so the 100ms ticks don't re-render the whole sheet.
+  const peakLevelRef = useRef(Number.NEGATIVE_INFINITY);
+  const meterIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Release handlers wait on this so they never race ahead of async recorder setup.
   const startPromiseRef = useRef<Promise<void> | null>(null);
@@ -32,12 +45,31 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
     isPreparedRef.current = true;
   }, [recorder]);
 
+  const startMetering = () => {
+    stopMetering();
+    peakLevelRef.current = Number.NEGATIVE_INFINITY;
+    meterIntervalRef.current = setInterval(() => {
+      const status = recorder.getStatus();
+      // iOS reports 0 dB (full scale) for averagePower while idle, so only trust a live take.
+      if (!status.isRecording || status.metering === undefined) return;
+      peakLevelRef.current = Math.max(peakLevelRef.current, status.metering);
+    }, METER_POLL_MS);
+  };
+
+  const stopMetering = () => {
+    if (meterIntervalRef.current !== null) {
+      clearInterval(meterIntervalRef.current);
+      meterIntervalRef.current = null;
+    }
+  };
+
   // Pre-warm on mount: a cold prepare takes 300-650ms, which would otherwise be
   // a dead window right after press-in where nothing is recorded yet. The
   // recording audio mode is process-global, so hand it back on unmount.
   useEffect(() => {
     prepareRecorder().catch((error) => console.warn("[Mic] Failed to pre-warm recorder.", error));
     return () => {
+      stopMetering();
       setAudioModeAsync({ allowsRecording: false, playsInSilentMode: true }).catch((error) =>
         console.warn("[Mic] Failed to reset audio mode.", error),
       );
@@ -68,6 +100,7 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
       await prepareRecorder();
       if (cancelRequested.current) return;
       recorder.record();
+      startMetering();
     } catch (error) {
       Toast.show({ type: "error", text1: t("errors.recordingFailed") });
       console.warn("[Mic] Error starting recording.", error);
@@ -88,14 +121,19 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
       trackRecordingFailure("RecordingCancelFailed");
       return;
     } finally {
+      stopMetering();
       isPreparedRef.current = false;
     }
 
-    // Best-effort cleanup of the discarded take, mirroring stopAndUpload.
+    if (recorder.uri) discardRecordingFile(recorder.uri);
+  };
+
+  // Best-effort cleanup of a temp recording; failure here shouldn't surface as an AI failure.
+  const discardRecordingFile = (uri: string) => {
     try {
-      if (recorder.uri) new ExpoFile(recorder.uri).delete();
+      new ExpoFile(uri).delete();
     } catch (error) {
-      console.warn("[Mic] Failed to delete cancelled recording file.", error);
+      console.warn("[Mic] Failed to delete temp recording file.", error);
     }
   };
 
@@ -116,12 +154,24 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
       trackRecordingFailure("RecordingStopFailed");
       return false;
     } finally {
+      stopMetering();
       isPreparedRef.current = false;
     }
 
     const uri = recorder.uri;
     if (!uri) {
       trackRecordingFailure("EmptyAudio");
+      return false;
+    }
+
+    if (__DEV__) console.log(`[Mic] Peak level ${peakLevelRef.current.toFixed(1)} dBFS.`);
+
+    // Nothing loud enough to be speech: don't let Whisper make something up.
+    if (peakLevelRef.current < SPEECH_LEVEL_DBFS) {
+      Toast.show({ type: "error", text1: t("errors.emptyAudio") });
+      console.warn(`[Mic] No speech detected (peak ${peakLevelRef.current} dBFS); take discarded.`);
+      trackRecordingFailure("NoSpeechDetected");
+      discardRecordingFile(uri);
       return false;
     }
 
@@ -137,13 +187,7 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
       return false;
     }
 
-    // Best-effort cleanup of the temp recording; failure here shouldn't surface as an AI failure.
-    try {
-      new ExpoFile(uri).delete();
-    } catch (error) {
-      console.warn("[Mic] Failed to delete temp recording file.", error);
-    }
-
+    discardRecordingFile(uri);
     return true;
   };
 

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
@@ -63,18 +63,23 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
     }
   };
 
-  // Pre-warm on mount: a cold prepare takes 300-650ms, which would otherwise be
-  // a dead window right after press-in where nothing is recorded yet. The
-  // recording audio mode is process-global, so hand it back on unmount.
+  // Set the recording audio mode up front, but do NOT open the mic input until press-in:
+  // iOS silences haptics while an audio input is open, so a recorder pre-warmed on mount
+  // swallowed the press haptic on the first hold. Opening on press costs 150-260ms on an
+  // iPhone 17 Pro (measured 2026-09-10), and the haptic is dispatched before it starts.
+  // Any haptic fired while recording must wait for the recorder to stop, for the same reason.
+  // The recording audio mode is process-global, so hand it back on unmount.
   useEffect(() => {
-    prepareRecorder().catch((error) => console.warn("[Mic] Failed to pre-warm recorder.", error));
+    setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true }).catch((error) =>
+      console.warn("[Mic] Failed to set recording audio mode.", error),
+    );
     return () => {
       stopMetering();
       setAudioModeAsync({ allowsRecording: false, playsInSilentMode: true }).catch((error) =>
         console.warn("[Mic] Failed to reset audio mode.", error),
       );
     };
-  }, [prepareRecorder]);
+  }, []);
 
   const trackRecordingFailure = (errorCode: string) => {
     analytics.trackAiTaskGenerationFailed({

--- a/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
+++ b/blotztask-mobile/src/feature/ai-task-generate/hooks/useVoiceRecorder.ts
@@ -9,24 +9,17 @@ import { File as ExpoFile } from "expo-file-system";
 import { useTranslation } from "react-i18next";
 import Toast from "react-native-toast-message";
 import { analytics } from "@/shared/services/analytics";
+import { usePeakLevelMeter } from "./usePeakLevelMeter";
 
-// Whisper invents text ("Thank you.") when the audio holds no speech, so a take whose loudest
-// moment never rises above this level is discarded before upload. Metering is dBFS on both
-// platforms (iOS averagePower, Android converted from maxAmplitude). Measured on an iPhone
-// 2026-09-10: a quiet room reads about -51, speech played from a laptop across the desk -42 to -35,
-// speech at max volume -15. -45 sits between silence and quiet speech; tune from the dev log below.
+// Takes that never get louder than this are dropped before upload: Whisper invents text
+// ("Thank you.") for silence. iPhone readings: quiet room -51, quiet speech -42, close speech -15.
 const SPEECH_LEVEL_DBFS = -45;
-const METER_POLL_MS = 100;
 
 export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => Promise<void>) {
   const { t } = useTranslation("aiTaskGenerate");
   const recorder = useAudioRecorder({ ...RecordingPresets.HIGH_QUALITY, isMeteringEnabled: true });
   const { isRecording } = useAudioRecorderState(recorder);
-
-  // Loudest level seen during the current take. Polled into a ref rather than through
-  // useAudioRecorderState so the 100ms ticks don't re-render the whole sheet.
-  const peakLevelRef = useRef(Number.NEGATIVE_INFINITY);
-  const meterIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const meter = usePeakLevelMeter(recorder);
 
   // Release handlers wait on this so they never race ahead of async recorder setup.
   const startPromiseRef = useRef<Promise<void> | null>(null);
@@ -45,36 +38,14 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
     isPreparedRef.current = true;
   }, [recorder]);
 
-  const startMetering = () => {
-    stopMetering();
-    peakLevelRef.current = Number.NEGATIVE_INFINITY;
-    meterIntervalRef.current = setInterval(() => {
-      const status = recorder.getStatus();
-      // iOS reports 0 dB (full scale) for averagePower while idle, so only trust a live take.
-      if (!status.isRecording || status.metering === undefined) return;
-      peakLevelRef.current = Math.max(peakLevelRef.current, status.metering);
-    }, METER_POLL_MS);
-  };
-
-  const stopMetering = () => {
-    if (meterIntervalRef.current !== null) {
-      clearInterval(meterIntervalRef.current);
-      meterIntervalRef.current = null;
-    }
-  };
-
-  // Set the recording audio mode up front, but do NOT open the mic input until press-in:
-  // iOS silences haptics while an audio input is open, so a recorder pre-warmed on mount
-  // swallowed the press haptic on the first hold. Opening on press costs 150-260ms on an
-  // iPhone 17 Pro (measured 2026-09-10), and the haptic is dispatched before it starts.
-  // Any haptic fired while recording must wait for the recorder to stop, for the same reason.
-  // The recording audio mode is process-global, so hand it back on unmount.
+  // Set the audio mode here, but open the mic only on press-in (150-260ms): iOS mutes haptics
+  // while the mic is open, so pre-warming on mount silenced the first press. Mode is global;
+  // hand it back on unmount.
   useEffect(() => {
     setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true }).catch((error) =>
       console.warn("[Mic] Failed to set recording audio mode.", error),
     );
     return () => {
-      stopMetering();
       setAudioModeAsync({ allowsRecording: false, playsInSilentMode: true }).catch((error) =>
         console.warn("[Mic] Failed to reset audio mode.", error),
       );
@@ -105,7 +76,7 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
       await prepareRecorder();
       if (cancelRequested.current) return;
       recorder.record();
-      startMetering();
+      meter.start();
     } catch (error) {
       Toast.show({ type: "error", text1: t("errors.recordingFailed") });
       console.warn("[Mic] Error starting recording.", error);
@@ -126,7 +97,7 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
       trackRecordingFailure("RecordingCancelFailed");
       return;
     } finally {
-      stopMetering();
+      meter.stop();
       isPreparedRef.current = false;
     }
 
@@ -159,7 +130,7 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
       trackRecordingFailure("RecordingStopFailed");
       return false;
     } finally {
-      stopMetering();
+      meter.stop();
       isPreparedRef.current = false;
     }
 
@@ -169,10 +140,10 @@ export function useVoiceRecorder(submitAudioForTranscription: (uri: string) => P
       return false;
     }
 
-    // Nothing loud enough to be speech: don't let Whisper make something up.
-    if (peakLevelRef.current < SPEECH_LEVEL_DBFS) {
+    const peakDbfs = meter.peakDbfs();
+    if (peakDbfs < SPEECH_LEVEL_DBFS) {
       Toast.show({ type: "error", text1: t("errors.emptyAudio") });
-      console.warn(`[Mic] No speech detected (peak ${peakLevelRef.current} dBFS); take discarded.`);
+      console.warn(`[Mic] No speech detected (peak ${peakDbfs.toFixed(1)} dBFS); take discarded.`);
       trackRecordingFailure("NoSpeechDetected");
       discardRecordingFile(uri);
       return false;

--- a/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
@@ -22,15 +22,14 @@ import Animated, {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { LinearGradient } from "expo-linear-gradient";
 import MaterialCommunityIcons from "@react-native-vector-icons/material-design-icons/static";
-import LottieView from "lottie-react-native";
 import { router } from "expo-router";
 import * as Haptics from "expo-haptics";
 import { getRecordingPermissionsAsync, requestRecordingPermissionsAsync } from "expo-audio";
 import { useTranslation } from "react-i18next";
-import { LOTTIE_ANIMATIONS } from "@/shared/constants/assets";
 import { AiResultList } from "../component/ai-result-list";
 import { VoiceHintText } from "../component/voice-hint-text";
 import { ListeningIndicator } from "../component/listening-indicator";
+import { HoldToTalkPill } from "../component/hold-to-talk-pill";
 import { useAiTaskGenerator } from "../hooks/useAiTaskGenerator";
 import { useVoiceRecorder } from "../hooks/useVoiceRecorder";
 import { useAllLabels } from "@/shared/hooks/useAllLabels";
@@ -49,18 +48,6 @@ import { toastConfig } from "@/shared/components/toast-config";
 // anything longer is a real recording and gets uploaded.
 const MIN_HOLD_MS = 300;
 const HOLD_HINT_AUTO_HIDE_MS = 2500;
-
-// Hold-to-talk pill: white with the sheet's blue while idle, brand green while pressed or
-// recording (the waveform Lottie is white, so it needs a coloured ground).
-const MIC_PILL_IDLE_FG = "#2F80ED";
-const MIC_PILL_ACTIVE_BG = "#9AD513";
-const micPillShadow = {
-  shadowColor: "#000",
-  shadowOpacity: 0.18,
-  shadowRadius: 8,
-  shadowOffset: { width: 0, height: 4 },
-  elevation: 5,
-} as const;
 
 export default function AiTaskSheetScreen() {
   // --- Hooks ---
@@ -257,8 +244,8 @@ export default function AiTaskSheetScreen() {
     );
     setIsHoldHintVisible(true);
     hideHoldHintLater();
-    // Release the mic first: iOS mutes haptics while an audio input is open.
-    await cancelListening();
+    await cancelListening(); // iOS mutes haptics while the mic is open
+
     void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
   };
 
@@ -379,61 +366,14 @@ export default function AiTaskSheetScreen() {
                     style={micShakeStyle}
                   >
                     {inputMode === "voice" ? (
-                      <Pressable
+                      <HoldToTalkPill
+                        isRecording={isRecording}
+                        disabled={isAiGenerating}
+                        minHoldMs={MIN_HOLD_MS}
                         onPressIn={handleMicPressIn}
                         onPressOut={handleMicRelease}
-                        onLongPress={markHeldLongEnough}
-                        delayLongPress={MIN_HOLD_MS}
-                        pressRetentionOffset={24}
-                        className="w-full"
-                        disabled={isAiGenerating}
-                      >
-                        {({ pressed }) => {
-                          // `pressed` flips the pill on the same frame as the touch, before the
-                          // recorder state catches up. Solid fill + shadow so it reads as a real
-                          // button against the gradient; the translucent pill looked like a label.
-                          const isActive = isRecording || pressed;
-                          return (
-                            <Animated.View
-                              className="w-full h-14 rounded-full flex-row items-center justify-center gap-2"
-                              style={[
-                                micPillShadow,
-                                {
-                                  backgroundColor: isActive ? MIC_PILL_ACTIVE_BG : "white",
-                                  opacity: isAiGenerating ? 0.5 : 1,
-                                  transform: [{ scale: pressed ? 0.97 : 1 }],
-                                  transitionProperty: ["transform", "backgroundColor"],
-                                  transitionDuration: 120,
-                                },
-                              ]}
-                            >
-                              {isRecording ? (
-                                <LottieView
-                                  source={LOTTIE_ANIMATIONS.voiceWave}
-                                  loop
-                                  autoPlay
-                                  style={{ width: "100%", height: 40 }}
-                                  resizeMode="contain"
-                                />
-                              ) : (
-                                <>
-                                  <MaterialCommunityIcons
-                                    name="microphone"
-                                    size={24}
-                                    color={isActive ? "white" : MIC_PILL_IDLE_FG}
-                                  />
-                                  <Text
-                                    className="font-balooBold text-base"
-                                    style={{ color: isActive ? "white" : MIC_PILL_IDLE_FG }}
-                                  >
-                                    {t("buttons.holdToTalk")}
-                                  </Text>
-                                </>
-                              )}
-                            </Animated.View>
-                          );
-                        }}
-                      </Pressable>
+                        onHeldLongEnough={markHeldLongEnough}
+                      />
                     ) : (
                       <TextInput
                         autoFocus

--- a/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
+++ b/blotztask-mobile/src/feature/ai-task-generate/screens/ai-task-sheet-screen.tsx
@@ -50,6 +50,18 @@ import { toastConfig } from "@/shared/components/toast-config";
 const MIN_HOLD_MS = 300;
 const HOLD_HINT_AUTO_HIDE_MS = 2500;
 
+// Hold-to-talk pill: white with the sheet's blue while idle, brand green while pressed or
+// recording (the waveform Lottie is white, so it needs a coloured ground).
+const MIC_PILL_IDLE_FG = "#2F80ED";
+const MIC_PILL_ACTIVE_BG = "#9AD513";
+const micPillShadow = {
+  shadowColor: "#000",
+  shadowOpacity: 0.18,
+  shadowRadius: 8,
+  shadowOffset: { width: 0, height: 4 },
+  elevation: 5,
+} as const;
+
 export default function AiTaskSheetScreen() {
   // --- Hooks ---
   const { t } = useTranslation("aiTaskGenerate");
@@ -239,14 +251,15 @@ export default function AiTaskSheetScreen() {
   };
 
   // Released before MIN_HOLD_MS: discard, but never silently.
-  const handleMicMisfire = () => {
-    void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+  const handleMicMisfire = async () => {
     micShakeX.value = withSequence(
       ...[-8, 8, -5, 5, 0].map((x) => withTiming(x, { duration: 50 })),
     );
     setIsHoldHintVisible(true);
     hideHoldHintLater();
-    void cancelListening();
+    // Release the mic first: iOS mutes haptics while an audio input is open.
+    await cancelListening();
+    void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
   };
 
   const handleMicSubmit = async () => {
@@ -260,7 +273,7 @@ export default function AiTaskSheetScreen() {
     if (heldLongEnough.current) {
       void handleMicSubmit();
     } else {
-      handleMicMisfire();
+      void handleMicMisfire();
     }
   };
 
@@ -371,34 +384,55 @@ export default function AiTaskSheetScreen() {
                         onPressOut={handleMicRelease}
                         onLongPress={markHeldLongEnough}
                         delayLongPress={MIN_HOLD_MS}
-                        className="w-full h-14 rounded-full flex-row items-center justify-center gap-2"
-                        style={({ pressed }) => ({
-                          // `pressed` lights the pill up immediately on touch, before
-                          // the recorder state catches up.
-                          backgroundColor:
-                            isRecording || pressed
-                              ? "rgba(255,255,255,0.5)"
-                              : "rgba(255,255,255,0.25)",
-                          opacity: isAiGenerating ? 0.4 : 1,
-                        })}
+                        pressRetentionOffset={24}
+                        className="w-full"
                         disabled={isAiGenerating}
                       >
-                        {isRecording ? (
-                          <LottieView
-                            source={LOTTIE_ANIMATIONS.voiceWave}
-                            loop
-                            autoPlay
-                            style={{ width: "100%", height: 40 }}
-                            resizeMode="contain"
-                          />
-                        ) : (
-                          <>
-                            <MaterialCommunityIcons name="microphone" size={24} color="white" />
-                            <Text className="text-white font-baloo text-base">
-                              {t("buttons.holdToTalk")}
-                            </Text>
-                          </>
-                        )}
+                        {({ pressed }) => {
+                          // `pressed` flips the pill on the same frame as the touch, before the
+                          // recorder state catches up. Solid fill + shadow so it reads as a real
+                          // button against the gradient; the translucent pill looked like a label.
+                          const isActive = isRecording || pressed;
+                          return (
+                            <Animated.View
+                              className="w-full h-14 rounded-full flex-row items-center justify-center gap-2"
+                              style={[
+                                micPillShadow,
+                                {
+                                  backgroundColor: isActive ? MIC_PILL_ACTIVE_BG : "white",
+                                  opacity: isAiGenerating ? 0.5 : 1,
+                                  transform: [{ scale: pressed ? 0.97 : 1 }],
+                                  transitionProperty: ["transform", "backgroundColor"],
+                                  transitionDuration: 120,
+                                },
+                              ]}
+                            >
+                              {isRecording ? (
+                                <LottieView
+                                  source={LOTTIE_ANIMATIONS.voiceWave}
+                                  loop
+                                  autoPlay
+                                  style={{ width: "100%", height: 40 }}
+                                  resizeMode="contain"
+                                />
+                              ) : (
+                                <>
+                                  <MaterialCommunityIcons
+                                    name="microphone"
+                                    size={24}
+                                    color={isActive ? "white" : MIC_PILL_IDLE_FG}
+                                  />
+                                  <Text
+                                    className="font-balooBold text-base"
+                                    style={{ color: isActive ? "white" : MIC_PILL_IDLE_FG }}
+                                  >
+                                    {t("buttons.holdToTalk")}
+                                  </Text>
+                                </>
+                              )}
+                            </Animated.View>
+                          );
+                        }}
                       </Pressable>
                     ) : (
                       <TextInput


### PR DESCRIPTION
## Summary

- A quick press-and-release sent Whisper near-silence, and it replied with "Thank you." / "谢谢大家" / a like-and-subscribe plea that became a fake task. Groq's turbo Whisper reports `no_speech_prob = 0` for silence, so confidence filtering can't help.
- App: meter the mic during the hold; discard the take before upload if it never rises above -45 dBFS (quiet room ≈ -51, close speech ≈ -15). Shows the existing "no voice detected" toast, no Groq quota spent.
- API: transcripts matching known no-speech phrases become `EmptyAudio` as a backstop.
- Press haptics were gone since #536: iOS mutes haptics while an audio input is open. Audio mode still set on mount, but the mic opens on press-in after the haptic (150–260 ms measured).
- Hold-to-talk pill restyled to read as a button (white/blue idle, green + waveform recording, shadow, press scale).
- Adds the `real-device-test` skill (drive the dev build on a real phone).

Verified on an iPhone 17 Pro: silence discarded, blocklist hit, speech → task, first-press haptic.

## Release note

> Voice input no longer turns an accidental tap into a made-up task, and the mic button responds with a clearer look and feel.

**Status:**

- [x] User-facing — announce it
- [ ] Beta / partial — announce, but tagged as beta
- [ ] Hidden in production (feature-flagged / not enabled for users) — don't announce
- [ ] Internal only (refactor / infra / tests / CI / deps) — don't announce

🤖 Generated with [Claude Code](https://claude.com/claude-code)
